### PR TITLE
Generate evm_production during rpm build

### DIFF
--- a/evm_override
+++ b/evm_override
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Description: Sets the environment for scripts and console users
+#
+
+export RAILS_ENV=production
+export APPLIANCE=true
+export HOME=${HOME:-/root}
+# Force ExecJS to use node
+export EXECJS_RUNTIME='Node'
+# workaround for virtual memory spike observed with RHEL6
+export MALLOC_ARENA_MAX=1
+# Location of certificates and provider keys
+export KEY_ROOT=/var/www/miq/vmdb/certs
+
+[[ -s /etc/default/evm_ruby ]] && source /etc/default/evm_ruby
+[[ -s /etc/default/evm_bundler ]] && source /etc/default/evm_bundler
+[[ -s /etc/default/evm_postgres ]] && source /etc/default/evm_postgres
+source /etc/default/evm_production
+
+# Force locale
+export LANGUAGE=en_US.UTF-8
+export LANG=en_US.UTF-8
+export LC_CTYPE=en_US.UTF-8
+
+[[ ":$PATH:" == *":/usr/local/bin:"* ]] || PATH="/usr/local/bin:${PATH}"

--- a/evm_productization
+++ b/evm_productization
@@ -1,4 +1,0 @@
-export APPLIANCE_SOURCE_DIRECTORY=/opt/manageiq/manageiq-appliance
-export APPLIANCE_TEMPLATE_DIRECTORY=${APPLIANCE_SOURCE_DIRECTORY}/TEMPLATE
-
-[[ -s /opt/manageiq/manageiq-gemset/enable ]] && source /opt/manageiq/manageiq-gemset/enable

--- a/lib/manageiq/rpm_build/setup_source_repos.rb
+++ b/lib/manageiq/rpm_build/setup_source_repos.rb
@@ -48,6 +48,8 @@ module ManageIQ
           git_clone("#{github_url}/#{repo_prefix}.git", "manageiq")
           git_clone("#{github_url}/#{repo_prefix}-ui-service.git", "manageiq-ui-service")
         end
+        # WORKAROUND
+        FileUtils.cp(ROOT_DIR.join("evm_override"), BUILD_DIR.join("manageiq-appliance/LINK/etc/default/evm"))
         post_setup_source_repo
       end
 

--- a/lib/manageiq/rpm_build/setup_source_repos.rb
+++ b/lib/manageiq/rpm_build/setup_source_repos.rb
@@ -21,7 +21,6 @@ module ManageIQ
         clean_build_dir
         setup_rpm_spec_repo
         setup_source_repo
-        FileUtils.cp(ROOT_DIR.join("evm_productization"), BUILD_DIR.join("manageiq-appliance/LINK/etc/default/"))
       end
 
       def clean_build_dir

--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -49,6 +49,12 @@ export GEM_PATH=%{gemset_root}:$(gem env path)
 export PATH=%{gemset_root}/bin:$PATH
 EOF
 
+cat <<"EOF" > %{appliance_builddir}/LINK/etc/default/evm_production
+export APPLIANCE_SOURCE_DIRECTORY=%{appliance_root}
+export APPLIANCE_TEMPLATE_DIRECTORY=${APPLIANCE_SOURCE_DIRECTORY}/TEMPLATE
+source %{gemset_root}/enable
+EOF
+
 %install
 cd %{_builddir}
 


### PR DESCRIPTION
evm_productization file contains paths that can change when productized. Changed to generate the file during rpm build, which knows the productized path.

Tested with [manageiq-appliance change](https://github.com/simaishi/manageiq-appliance/commit/149509e3e96eeacc8ca3e0abad31caa49ceb0aec)