### PR TITLE
Use the config gem to simplify options and overrides

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'awesome_spawn'
+gem 'config'
 gem 'optimist'
 gem 'rake'
 gem 'term-ansicolor'

--- a/config/options.yml
+++ b/config/options.yml
@@ -1,6 +1,4 @@
 ---
-build_dir:       ~/BUILD
-
 product_name:    manageiq
 
 github_url:      https://github.com/ManageIQ

--- a/lib/manageiq/rpm_build.rb
+++ b/lib/manageiq/rpm_build.rb
@@ -1,3 +1,4 @@
+require 'config'
 require 'pathname'
 require 'yaml'
 
@@ -18,15 +19,13 @@ module ManageIQ
     CONFIG_DIR   = ROOT_DIR.join("config")
     SCRIPT_DIR   = ROOT_DIR.join("scripts")
 
-    options      = YAML.load_file(CONFIG_DIR.join("options.yml"))
-    BUILD_DIR    = Pathname.new(options["build_dir"]).expand_path
+    BUILD_DIR    = Pathname.new(ENV.fetch("BUILD_DIR", "~/BUILD")).expand_path
     RPM_SPEC_DIR = BUILD_DIR.join("rpm_spec")
 
-    PRODUCT_NAME = options["product_name"]
-    VERSION      = options["version"]
-    RELEASE      = options["release"]
+    OPTIONS_DIR  = Pathname.new(ENV.fetch("OPTIONS_DIR", "~/OPTIONS")).expand_path
+    OPTIONS      = Config.load_files(CONFIG_DIR.join("options.yml"), OPTIONS_DIR.join("options.yml"))
 
     BUILD_DATE   = Time.now.strftime("%Y%m%d%H%M%S")
-    GEM_HOME     = BUILD_DIR.join("#{PRODUCT_NAME}-gemset-#{VERSION}")
+    GEM_HOME     = BUILD_DIR.join("#{OPTIONS.product_name}-gemset-#{OPTIONS.version}")
   end
 end

--- a/lib/manageiq/rpm_build/build_copr.rb
+++ b/lib/manageiq/rpm_build/build_copr.rb
@@ -10,12 +10,9 @@ module ManageIQ
       attr_reader :release_name, :rpm_release, :rpm_repo_name
 
       def initialize(release_name)
-        @release_name = release_name
-
-        options        = YAML.load_file(CONFIG_DIR.join("options.yml"))
-        rpm_options    = options["rpm"]
-        @rpm_release   = rpm_options["release"]
-        @rpm_repo_name = rpm_options["repo_name"]
+        @release_name  = release_name
+        @rpm_release   = OPTIONS.rpm.release
+        @rpm_repo_name = OPTIONS.rpm.repo_name
       end
 
       def generate_rpm
@@ -26,8 +23,8 @@ module ManageIQ
           update_spec
 
           #TODO - need to allow customization
-          shell_cmd("rpmbuild -bs --define '_sourcedir .' --define '_srcrpmdir .' #{PRODUCT_NAME}.spec")
-          shell_cmd("copr-cli --config /build_scripts/copr-cli-token build -r epel-8-x86_64 #{rpm_repo_name} #{PRODUCT_NAME}-*.src.rpm")
+          shell_cmd("rpmbuild -bs --define '_sourcedir .' --define '_srcrpmdir .' #{OPTIONS.product_name}.spec")
+          shell_cmd("copr-cli --config /build_scripts/copr-cli-token build -r epel-8-x86_64 #{rpm_repo_name} #{OPTIONS.product_name}-*.src.rpm")
         end
       end
 
@@ -39,7 +36,7 @@ module ManageIQ
           manageiq_spec.sub!("%changelog", "#{subpackage_spec}\n\n%changelog")
         end
 
-        File.write("#{PRODUCT_NAME}.spec", manageiq_spec)
+        File.write("#{OPTIONS.product_name}.spec", manageiq_spec)
       end
 
       private
@@ -50,7 +47,7 @@ module ManageIQ
         spec_file = "#{rpm_name}.spec"
         spec_text = File.read(spec_file)
 
-        spec_text.sub!("RPM_VERSION", VERSION)
+        spec_text.sub!("RPM_VERSION", OPTIONS.version)
         spec_text.sub!("RPM_RELEASE", spec_release)
         File.write(spec_file, spec_text)
       end

--- a/lib/manageiq/rpm_build/generate_core.rb
+++ b/lib/manageiq/rpm_build/generate_core.rb
@@ -23,7 +23,7 @@ module ManageIQ
       end
 
       def release_file
-        File.write(miq_dir.join("RELEASE"), RELEASE)
+        File.write(miq_dir.join("RELEASE"), OPTIONS.release)
       end
 
       def link_plugin_public_dirs

--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -12,9 +12,7 @@ module ManageIQ
 
       def initialize
         where_am_i
-
-        options = YAML.load_file(CONFIG_DIR.join("options.yml"))
-        @bundler_version  = options["bundler_version"]
+        @bundler_version = OPTIONS.bundler_version
       end
 
       def backup_environment_variables

--- a/lib/manageiq/rpm_build/generate_tar_files.rb
+++ b/lib/manageiq/rpm_build/generate_tar_files.rb
@@ -44,7 +44,7 @@ module ManageIQ
       private
 
       def tar_basename(name)
-        "#{PRODUCT_NAME}-#{name}-#{VERSION}"
+        "#{OPTIONS.product_name}-#{name}-#{OPTIONS.version}"
       end
 
       def transform(name)

--- a/lib/manageiq/rpm_build/setup_source_repos.rb
+++ b/lib/manageiq/rpm_build/setup_source_repos.rb
@@ -11,11 +11,9 @@ module ManageIQ
 
       def initialize(ref)
         where_am_i
-        options = YAML.load_file(CONFIG_DIR.join("options.yml"))
-
-        @git_ref      = ref || options["git_ref"]
-        @github_url   = options["github_url"]
-        @repo_prefix  = options["repo_prefix"]
+        @git_ref     = ref || OPTIONS.git_ref
+        @github_url  = OPTIONS.github_url
+        @repo_prefix = OPTIONS.repo_prefix
       end
 
       def populate
@@ -37,9 +35,9 @@ module ManageIQ
         FileUtils.mkdir_p RPM_SPEC_DIR
         FileUtils.cp_r("/build_scripts/rpm_spec", BUILD_DIR)
         Dir.chdir(RPM_SPEC_DIR) do
-          #git_clone("#{github_url}/#{PRODUCT_NAME}-gemset.git")
-          #git_clone("#{github_url}/#{PRODUCT_NAME}.git")
-          #git_clone("#{github_url}/#{PRODUCT_NAME}-appliance.git")
+          #git_clone("#{github_url}/#{OPTIONS.product_name}-gemset.git")
+          #git_clone("#{github_url}/#{OPTIONS.product_name}.git")
+          #git_clone("#{github_url}/#{OPTIONS.product_name}-appliance.git")
         end
       end
 


### PR DESCRIPTION
@simaishi Please review.

This PR also brings the ~/OPTIONS directory which can be brought in as a docker volume if needed to override things.  If an options.yml is found there it will override values from config/options.yml

I've also defaulted to ~/OPTIONS and ~/BUILD for simplicity, but allowed those to be overridden with ENV vars even if unlikely.