### PR TITLE
Productization fix to make build/install work with customized name

### DIFF
--- a/bin/build.rb
+++ b/bin/build.rb
@@ -39,7 +39,7 @@ puts "\n\nTARBALL BUILT SUCCESSFULLY"
 # Build RPMs
 if ENV['COPR_RPM_BUILD']
   release_name = build_type == "release" ? git_ref : ""
-  ManageIQ::RPMBuild::BuildCopr.new("manageiq", release_name).generate_rpm
+  ManageIQ::RPMBuild::BuildCopr.new(release_name).generate_rpm
 end
 
 puts "\n\nRPM BUILT SUCCESSFULLY"

--- a/config/options.yml
+++ b/config/options.yml
@@ -2,8 +2,11 @@
 build_dir:       ~/BUILD
 
 product_name:    manageiq
+
 github_url:      https://github.com/ManageIQ
 git_ref:         master
+repo_prefix:     manageiq
+
 version:         11.0.0
 release:         Kasparov
 rpm:

--- a/lib/manageiq/rpm_build/build_copr.rb
+++ b/lib/manageiq/rpm_build/build_copr.rb
@@ -7,10 +7,9 @@ module ManageIQ
     class BuildCopr
       include Helper
 
-      attr_reader :release_name, :rpm_name, :rpm_release, :rpm_repo_name
+      attr_reader :release_name, :rpm_release, :rpm_repo_name
 
-      def initialize(name, release_name)
-        @rpm_name     = name
+      def initialize(release_name)
         @release_name = release_name
 
         options        = YAML.load_file(CONFIG_DIR.join("options.yml"))
@@ -27,13 +26,13 @@ module ManageIQ
           update_spec
 
           #TODO - need to allow customization
-          shell_cmd("rpmbuild -bs --define '_sourcedir .' --define '_srcrpmdir .' #{rpm_name}.spec")
-          shell_cmd("copr-cli --config /build_scripts/copr-cli-token build -r epel-8-x86_64 #{rpm_repo_name} #{rpm_name}-*.src.rpm")
+          shell_cmd("rpmbuild -bs --define '_sourcedir .' --define '_srcrpmdir .' #{PRODUCT_NAME}.spec")
+          shell_cmd("copr-cli --config /build_scripts/copr-cli-token build -r epel-8-x86_64 #{rpm_repo_name} #{PRODUCT_NAME}-*.src.rpm")
         end
       end
 
       def generate_spec_from_subpackage_files
-        manageiq_spec = File.read("#{PRODUCT_NAME}.spec.in")
+        manageiq_spec = File.read("manageiq.spec.in")
 
         Dir.glob("subpackages/*").sort.each do |spec|
           subpackage_spec = File.read(spec)

--- a/lib/manageiq/rpm_build/setup_source_repos.rb
+++ b/lib/manageiq/rpm_build/setup_source_repos.rb
@@ -7,7 +7,7 @@ module ManageIQ
     class SetupSourceRepos
       include Helper
 
-      attr_reader :git_ref, :github_url
+      attr_reader :git_ref, :github_url, :repo_prefix
 
       def initialize(ref)
         where_am_i
@@ -15,6 +15,7 @@ module ManageIQ
 
         @git_ref      = ref || options["git_ref"]
         @github_url   = options["github_url"]
+        @repo_prefix  = options["repo_prefix"]
       end
 
       def populate
@@ -45,10 +46,10 @@ module ManageIQ
       def setup_source_repo
         where_am_i
         Dir.chdir(BUILD_DIR) do
-          git_clone("#{github_url}/#{PRODUCT_NAME}-appliance-build.git", "manageiq-appliance-build")
-          git_clone("#{github_url}/#{PRODUCT_NAME}-appliance.git", "manageiq-appliance")
-          git_clone("#{github_url}/#{PRODUCT_NAME}.git", "manageiq")
-          git_clone("#{github_url}/#{PRODUCT_NAME}-ui-service.git", "manageiq-ui-service")
+          git_clone("#{github_url}/#{repo_prefix}-appliance-build.git", "manageiq-appliance-build")
+          git_clone("#{github_url}/#{repo_prefix}-appliance.git", "manageiq-appliance")
+          git_clone("#{github_url}/#{repo_prefix}.git", "manageiq")
+          git_clone("#{github_url}/#{repo_prefix}-ui-service.git", "manageiq-ui-service")
         end
       end
 

--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -1,27 +1,33 @@
-%global app_root /var/www/miq/vmdb
-%global appliance_root /opt/manageiq/manageiq-appliance
-%global gemset_root /opt/manageiq/manageiq-gemset
+%global org_name manageiq
+%global product_name ManageIQ
+%global product_short_name manageiq
+%global product_summary ManageIQ Management Engine
+%global product_url https://github.com/ManageIQ/manageiq
 
-%global appliance_builddir manageiq-appliance-%{version}
-%global core_builddir manageiq-core-%{version}
-%global gemset_builddir manageiq-gemset-%{version}
+%global app_root /var/www/miq/vmdb
+%global appliance_root /opt/%{org_name}/%{name}-appliance
+%global gemset_root /opt/%{org_name}/%{name}-gemset
+
+%global appliance_builddir %{name}-appliance-%{version}
+%global core_builddir %{name}-core-%{version}
+%global gemset_builddir %{name}-gemset-%{version}
 
 %global debug_package %{nil}
 
-Name:     manageiq
+Name:     %{product_short_name}
 Version:  RPM_VERSION
 Release:  RPM_RELEASE%{?dist}
-Summary:  ManageIQ Management Engine
+Summary:  %{product_summary}
 
 License:  Apache-2.0
-URL:      https://github.com/ManageIQ/manageiq
+URL:      %{product_url}
 
 Source0:  %{name}-appliance-%{version}.tar.gz
 Source1:  %{name}-core-%{version}.tar.gz
 Source2:  %{name}-gemset-%{version}.tar.gz
 
 %description
-ManageIQ Management Engine
+%{product_summary}
 
 %prep
 %setup -q -n %{appliance_builddir}

--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -1,8 +1,8 @@
 %package appliance
-Summary:  ManageIQ Management Engine Appliance
+Summary: %{product_summary} Appliance
 
-Requires: manageiq-system = %{version}-%{release}
-Requires: manageiq-ui = %{version}-%{release}
+Requires: %{name}-system = %{version}-%{release}
+Requires: %{name}-ui = %{version}-%{release}
 
 Requires: postgresql-server
 Requires: repmgr10 >= 4.0.6
@@ -53,7 +53,7 @@ Requires: yum-utils
 Requires: postfix
 
 %description appliance
-ManageIQ Management Engine Appliance
+%{product_summary} Appliance
 
 %pretrans appliance -p <lua>
 if posix.access('/bin/evmserver.sh', 'x') then

--- a/rpm_spec/subpackages/manageiq-appliance-tools
+++ b/rpm_spec/subpackages/manageiq-appliance-tools
@@ -1,5 +1,5 @@
 %package appliance-tools
-Summary:  ManageIQ Management Engine appliance tools
+Summary:  %{product_summary} Appliance Tools
 Requires: less
 Requires: nano
 Requires: smem
@@ -9,6 +9,6 @@ Requires: vim-enhanced
 Requires: wget
 
 %description appliance-tools
-ManageIQ Management Engine appliance tools
+%{product_summary} Appliance Tools
 
 %files appliance-tools

--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -1,8 +1,8 @@
 %package core
-Summary:  ManageIQ Management Engine Core
+Summary:  %{product_summary} Core
 
 Requires: ruby
-Requires: manageiq-gemset = %{version}-%{release}
+Requires: %{name}-gemset = %{version}-%{release}
 
 Requires: ansible
 Requires: ansible-runner
@@ -15,7 +15,7 @@ Requires: net-snmp-utils
 Requires: socat
 
 %description core
-ManageIQ Management Engine Core
+%{product_summary} Core
 
 %posttrans core
 # 'bin' needs to be copied, not symlinked

--- a/rpm_spec/subpackages/manageiq-gemset
+++ b/rpm_spec/subpackages/manageiq-gemset
@@ -1,5 +1,5 @@
 %package gemset
-Summary:   ManageIQ Management Engine Gemset
+Summary: %{product_summary} Gemset
 BuildRequires: /usr/bin/pathfix.py
 
 Requires: cifs-utils
@@ -25,7 +25,7 @@ Requires: v2v-conversion-host-ansible
 Requires: network-scripts
 
 %description gemset
-ManageIQ Management Engine Gemset
+%{product_summary} Gemset
 
 %files gemset
 %defattr(-,root,root,-)

--- a/rpm_spec/subpackages/manageiq-pods
+++ b/rpm_spec/subpackages/manageiq-pods
@@ -1,9 +1,9 @@
 %package pods
-Summary: ManageIQ Management Engine Pods
-Requires: manageiq-system = %{version}-%{release}
-Requires: manageiq-core = %{version}-%{release}
+Summary: %{product_summary} Pods
+Requires: %{name}-system = %{version}-%{release}
+Requires: %{name}-core = %{version}-%{release}
 
 %description pods
-ManageIQ Management Engine Pods
+%{product_summary} Pods
 
 %files pods

--- a/rpm_spec/subpackages/manageiq-system
+++ b/rpm_spec/subpackages/manageiq-system
@@ -1,5 +1,5 @@
 %package system
-Summary:  ManageIQ Management Engine System
+Summary:  %{product_summary} System
 Requires: nmap-ncat
 
 # For log rotate
@@ -10,7 +10,7 @@ Requires: logrotate
 Requires: openldap-clients
 
 %description system
-ManageIQ Management Engine System
+%{product_summary} System
 
 %files system
 %defattr(-,root,root,-)

--- a/rpm_spec/subpackages/manageiq-ui
+++ b/rpm_spec/subpackages/manageiq-ui
@@ -1,9 +1,9 @@
 %package ui
-Summary: ManageIQ Management Engine UI
-Requires: manageiq-core = %{version}-%{release}
+Summary: %{product_summary} UI
+Requires: %{name}-core = %{version}-%{release}
 
 %description ui
-ManageIQ Management Engine UI
+%{product_summary} UI
 
 %files ui
 %defattr(-,root,root,-)


### PR DESCRIPTION
Changes needed to make RPM build/install work with customized names.

For now, a few variables in .spec.in and config/options.yml need go be modified. There will be some cleanup coming to make it easier to handle those.