### PR TITLE
No need to require same version-release RPMs for all subpackages

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -1,8 +1,8 @@
 %package appliance
 Summary: %{product_summary} Appliance
 
-Requires: %{name}-system = %{version}-%{release}
-Requires: %{name}-ui = %{version}-%{release}
+Requires: %{name}-system = %{version}
+Requires: %{name}-ui = %{version}
 
 Requires: postgresql-server
 Requires: repmgr10 >= 4.0.6

--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -2,7 +2,7 @@
 Summary:  %{product_summary} Core
 
 Requires: ruby
-Requires: %{name}-gemset = %{version}-%{release}
+Requires: %{name}-gemset = %{version}
 
 Requires: ansible
 Requires: ansible-runner

--- a/rpm_spec/subpackages/manageiq-pods
+++ b/rpm_spec/subpackages/manageiq-pods
@@ -1,7 +1,7 @@
 %package pods
 Summary: %{product_summary} Pods
-Requires: %{name}-system = %{version}-%{release}
-Requires: %{name}-core = %{version}-%{release}
+Requires: %{name}-system = %{version}
+Requires: %{name}-core = %{version}
 
 %description pods
 %{product_summary} Pods

--- a/rpm_spec/subpackages/manageiq-ui
+++ b/rpm_spec/subpackages/manageiq-ui
@@ -1,6 +1,6 @@
 %package ui
 Summary: %{product_summary} UI
-Requires: %{name}-core = %{version}-%{release}
+Requires: %{name}-core = %{version}
 
 %description ui
 %{product_summary} UI


### PR DESCRIPTION
Since all RPMs are now built as subpackages, no need to require the exact same `<version>-<release>`.

This will allow hotfix to be applied just for needed RPMs.

A part of https://github.com/ManageIQ/manageiq-rpm_build/issues/9