### PR TITLE
Allow rpm spec to be customized from options.yml

### DIFF
--- a/bin/generate_spec.rb
+++ b/bin/generate_spec.rb
@@ -1,13 +1,15 @@
 #!/usr/bin/env ruby
 
-require 'pathname'
+$LOAD_PATH << File.expand_path("../lib", __dir__)
 
-spec_dir = Pathname.new("../rpm_spec").expand_path(__dir__)
-manageiq_spec = spec_dir.join("manageiq.spec.in").read
+require 'manageiq/rpm_build'
+require 'optimist'
 
-Dir.glob("#{spec_dir.join("subpackages/*")}").sort.each do |spec|
-  subpackage_spec = File.read(spec)
-  manageiq_spec.sub!("%changelog", "#{subpackage_spec}\n\n%changelog")
+opts = Optimist.options do
+  opt :release_name, "release name (e.g. jansa-1) if release build", :type => :string
 end
 
-spec_dir.join("manageiq.spec").write(manageiq_spec)
+spec_dir = Pathname.new("../rpm_spec").expand_path(__dir__)
+Dir.chdir(spec_dir) do
+  ManageIQ::RPMBuild::BuildCopr.new(opts[:release_name].to_s).generate_spec_from_template
+end

--- a/config/options.yml
+++ b/config/options.yml
@@ -1,13 +1,16 @@
 ---
-product_name:    manageiq
-github_url:      https://github.com/ManageIQ
-git_ref:         master
-repo_prefix:     manageiq
+product_name:      manageiq
+github_url:        https://github.com/ManageIQ
+git_ref:           master
+repo_prefix:       manageiq
 version:
 release:
 rpm:
-  version:       11.0.0
-  release:       0.1
+  version:         11.0.0
+  release:         0.1
   repo_name:
-bundler_version: 2.1.4
+  org_name:        manageiq
+  product_summary: ManageIQ Management Engine
+  product_url:     https://github.com/ManageIQ/manageiq
+bundler_version:   2.1.4
 npm_registry:

--- a/lib/manageiq/rpm_build/build_copr.rb
+++ b/lib/manageiq/rpm_build/build_copr.rb
@@ -20,8 +20,7 @@ module ManageIQ
         where_am_i
 
         Dir.chdir(RPM_SPEC_DIR) do
-          generate_spec_from_subpackage_files
-          update_spec
+          generate_spec_from_template
 
           if File.exist?(File.expand_path("~/.config/copr"))
             shell_cmd("rpmbuild -bs --define '_sourcedir #{RPM_SPEC_DIR}' --define '_srcrpmdir #{RPM_SPEC_DIR}' #{rpm_spec}")
@@ -32,7 +31,7 @@ module ManageIQ
         end
       end
 
-      def generate_spec_from_subpackage_files
+      def generate_spec_from_template
         manageiq_spec = File.read("manageiq.spec.in")
 
         Dir.glob("subpackages/*").sort.each do |spec|
@@ -41,6 +40,7 @@ module ManageIQ
         end
 
         File.write(rpm_spec, manageiq_spec)
+        update_spec
       end
 
       private

--- a/lib/manageiq/rpm_build/build_copr.rb
+++ b/lib/manageiq/rpm_build/build_copr.rb
@@ -50,8 +50,12 @@ module ManageIQ
 
         spec_text = File.read(rpm_spec)
 
-        spec_text.sub!("RPM_VERSION", OPTIONS.rpm.version)
+        spec_text.sub!("ORG_NAME", OPTIONS.rpm.org_name)
+        spec_text.sub!("PRODUCT_NAME", OPTIONS.product_name)
+        spec_text.sub!("PRODUCT_SUMMARY", OPTIONS.rpm.product_summary)
+        spec_text.sub!("PRODUCT_URL", OPTIONS.rpm.product_url)
         spec_text.sub!("RPM_RELEASE", spec_release)
+        spec_text.sub!("RPM_VERSION", OPTIONS.rpm.version)
         File.write(rpm_spec, spec_text)
       end
 

--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -1,8 +1,7 @@
-%global org_name manageiq
-%global product_name ManageIQ
-%global product_short_name manageiq
-%global product_summary ManageIQ Management Engine
-%global product_url https://github.com/ManageIQ/manageiq
+%global org_name ORG_NAME
+%global product_name PRODUCT_NAME
+%global product_summary PRODUCT_SUMMARY
+%global product_url PRODUCT_URL
 
 %global app_root /var/www/miq/vmdb
 %global appliance_root /opt/%{org_name}/%{name}-appliance
@@ -14,7 +13,7 @@
 
 %global debug_package %{nil}
 
-Name:     %{product_short_name}
+Name:     %{product_name}
 Version:  RPM_VERSION
 Release:  RPM_RELEASE%{?dist}
 Summary:  %{product_summary}


### PR DESCRIPTION
3 options are added:
```
rpm:
  org_name:        manageiq
  product_summary: ManageIQ Management Engine
  product_url:     https://github.com/ManageIQ/manageiq
```

- org_name is used to set path to gemset/appliance source in rpm spec file, `/opt/<org_name>/<product_name>`
- product_summary and product_url are used for RPM metadata only

Also updated generate_spec.rb to use the same method as build. By using OPTIONS_DIR env variable, the customized spec can be generated as well.
```
OPTIONS_DIR=~/OPTIONS bin/generate_spec.rb
```

A part of #2 