### PR TITLE
Remove appliance build clone

### DIFF
--- a/config/options.yml
+++ b/config/options.yml
@@ -8,9 +8,6 @@ repos:
   manageiq_appliance:
     url:           https://github.com/ManageIQ/manageiq-appliance.git
     ref:
-  manageiq_appliance_build:
-    url:           https://github.com/ManageIQ/manageiq-appliance-build.git
-    ref:
   manageiq_ui_service:
     url:           https://github.com/ManageIQ/manageiq-ui-service.git
     ref:

--- a/config/options.yml
+++ b/config/options.yml
@@ -1,8 +1,19 @@
 ---
 product_name:      manageiq
-github_url:        https://github.com/ManageIQ
-git_ref:           master
-repo_prefix:       manageiq
+repos:
+  ref:             master
+  manageiq:
+    url:           https://github.com/ManageIQ/manageiq.git
+    ref:
+  manageiq_appliance:
+    url:           https://github.com/ManageIQ/manageiq-appliance.git
+    ref:
+  manageiq_appliance_build:
+    url:           https://github.com/ManageIQ/manageiq-appliance-build.git
+    ref:
+  manageiq_ui_service:
+    url:           https://github.com/ManageIQ/manageiq-ui-service.git
+    ref:
 version:
 release:
 rpm:

--- a/lib/manageiq/rpm_build/setup_source_repos.rb
+++ b/lib/manageiq/rpm_build/setup_source_repos.rb
@@ -7,13 +7,11 @@ module ManageIQ
     class SetupSourceRepos
       include Helper
 
-      attr_reader :git_ref, :github_url, :repo_prefix
+      attr_reader :git_ref
 
       def initialize(ref)
         where_am_i
-        @git_ref     = ref || OPTIONS.git_ref
-        @github_url  = OPTIONS.github_url
-        @repo_prefix = OPTIONS.repo_prefix
+        @git_ref = ref || OPTIONS.repos.ref
       end
 
       def populate
@@ -31,22 +29,16 @@ module ManageIQ
 
       def setup_rpm_spec_repo
         where_am_i
-        FileUtils.mkdir_p RPM_SPEC_DIR
-        FileUtils.cp_r("/build_scripts/rpm_spec", BUILD_DIR)
-        Dir.chdir(RPM_SPEC_DIR) do
-          #git_clone("#{github_url}/#{OPTIONS.product_name}-gemset.git")
-          #git_clone("#{github_url}/#{OPTIONS.product_name}.git")
-          #git_clone("#{github_url}/#{OPTIONS.product_name}-appliance.git")
-        end
+        FileUtils.cp_r("/build_scripts/rpm_spec", RPM_SPEC_DIR)
       end
 
       def setup_source_repo
         where_am_i
         Dir.chdir(BUILD_DIR) do
-          git_clone("#{github_url}/#{repo_prefix}-appliance-build.git", "manageiq-appliance-build")
-          git_clone("#{github_url}/#{repo_prefix}-appliance.git", "manageiq-appliance")
-          git_clone("#{github_url}/#{repo_prefix}.git", "manageiq")
-          git_clone("#{github_url}/#{repo_prefix}-ui-service.git", "manageiq-ui-service")
+          git_clone(OPTIONS.repos.manageiq_appliance_build, "manageiq-appliance-build")
+          git_clone(OPTIONS.repos.manageiq_appliance, "manageiq-appliance")
+          git_clone(OPTIONS.repos.manageiq, "manageiq")
+          git_clone(OPTIONS.repos.manageiq_ui_service, "manageiq-ui-service")
         end
         # WORKAROUND
         FileUtils.cp(ROOT_DIR.join("evm_override"), BUILD_DIR.join("manageiq-appliance/LINK/etc/default/evm"))
@@ -63,9 +55,9 @@ module ManageIQ
 
       private
 
-      def git_clone(repo_url, destination = nil)
-        destination ||= File.basename(repo_url, ".git")
-        exit $?.exitstatus unless system("git clone --depth 1 -b #{git_ref} #{repo_url} #{destination}")
+      def git_clone(repo_options, destination)
+        repo_ref = repo_options.ref || git_ref
+        shell_cmd("git clone --depth 1 -b #{repo_ref} #{repo_options.url} #{destination}")
       end
     end
   end

--- a/lib/manageiq/rpm_build/setup_source_repos.rb
+++ b/lib/manageiq/rpm_build/setup_source_repos.rb
@@ -35,7 +35,6 @@ module ManageIQ
       def setup_source_repo
         where_am_i
         Dir.chdir(BUILD_DIR) do
-          git_clone(OPTIONS.repos.manageiq_appliance_build, "manageiq-appliance-build")
           git_clone(OPTIONS.repos.manageiq_appliance, "manageiq-appliance")
           git_clone(OPTIONS.repos.manageiq, "manageiq")
           git_clone(OPTIONS.repos.manageiq_ui_service, "manageiq-ui-service")


### PR DESCRIPTION
Built on top of #41 

`manageiq-appliance-build` repo doesn't get used to build RPMs. 