### PR TITLE
Exclude jruby from being added to RPM dependency list

### DIFF
--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -12,6 +12,7 @@
 %global gemset_builddir %{name}-gemset-%{version}
 
 %global debug_package %{nil}
+%global __requires_exclude ^\/usr\/bin\/jruby
 
 Name:     %{product_name}
 Version:  RPM_VERSION


### PR DESCRIPTION
Due to `manageiq-api-client` gem update, `json` is now installed in bundle (as opposed to using the version that comes with ruby). This added `jruby` to RPM dependency automatically. Since that's not required, excluding from the dependency scanning.

I was going to exclude entire gemset directory, but there are other libraries that get picked up by the scan which should stay, so excluding just jruby.