### PR TITLE
Revert Merge pull request #36 (No need to require same version-release RPMs)

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -1,8 +1,8 @@
 %package appliance
 Summary: %{product_summary} Appliance
 
-Requires: %{name}-system = %{version}
-Requires: %{name}-ui = %{version}
+Requires: %{name}-system = %{version}-%{release}
+Requires: %{name}-ui = %{version}-%{release}
 
 Requires: postgresql-server
 Requires: repmgr10 >= 4.0.6

--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -2,7 +2,7 @@
 Summary:  %{product_summary} Core
 
 Requires: ruby
-Requires: %{name}-gemset = %{version}
+Requires: %{name}-gemset = %{version}-%{release}
 
 Requires: ansible
 Requires: ansible-runner

--- a/rpm_spec/subpackages/manageiq-pods
+++ b/rpm_spec/subpackages/manageiq-pods
@@ -1,7 +1,7 @@
 %package pods
 Summary: %{product_summary} Pods
-Requires: %{name}-system = %{version}
-Requires: %{name}-core = %{version}
+Requires: %{name}-system = %{version}-%{release}
+Requires: %{name}-core = %{version}-%{release}
 
 Requires: glibc-langpack-en
 Requires: procps-ng

--- a/rpm_spec/subpackages/manageiq-ui
+++ b/rpm_spec/subpackages/manageiq-ui
@@ -1,6 +1,6 @@
 %package ui
 Summary: %{product_summary} UI
-Requires: %{name}-core = %{version}
+Requires: %{name}-core = %{version}-%{release}
 Requires: httpd
 
 %description ui


### PR DESCRIPTION
Reverting #36, as I realized not requiring the same version-release can make RPMs out-of-sync for nightly build updates.

Need to think about how to make hotfix work, but for now, reverting this change.

