### PR TITLE
Update for jansa branch

### DIFF
--- a/config/options.yml
+++ b/config/options.yml
@@ -1,7 +1,7 @@
 ---
 product_name:      manageiq
 repos:
-  ref:             master
+  ref:             jansa
   manageiq:
     url:           https://github.com/ManageIQ/manageiq.git
     ref:
@@ -14,8 +14,8 @@ repos:
 version:
 release:
 rpm:
-  version:         11.0.0
-  release:         0.1
+  version:         10.1.0
+  release:         0.2
   repo_name:
   org_name:        manageiq
   product_summary: ManageIQ Management Engine


### PR DESCRIPTION
Since we already had jansa-1-alpha release, I'm setting the version to `10.1.0-0.2` as per https://github.com/ManageIQ/manageiq-rpm_build/issues/4#issuecomment-618633438

```
jansa (nightly) - 10.1.0-0.1.yyyymmddhhmmss
jansa-1-alpha1 - 10.1.0-0.2.alpha1
jansa (nightly) - 10.1.0-0.2.yyyymmddhhmmss
jansa-1-beta1 - 10.1.0-0.3.beta1
jansa-1 - 10.1.0-1
jansa-2 - 10.2.0-1
jansa-2.1 - 10.2.1-1
jansa-2.1 (but with RPM change) - 10.2.1-2
```