### PR TITLE
Move ovirt-ansible-roles requires from kickstart to manageiq-gemset

### DIFF
--- a/rpm_spec/subpackages/manageiq-gemset
+++ b/rpm_spec/subpackages/manageiq-gemset
@@ -25,6 +25,9 @@ Requires: cyrus-sasl
 Requires: cyrus-sasl-plain
 Requires: qpid-proton-c
 
+# For RHV
+Requires: ovirt-ansible-roles
+
 # For IMS
 Requires: v2v-conversion-host-ansible
 


### PR DESCRIPTION
A part of https://github.com/ManageIQ/manageiq-appliance-build/issues/422

Since `python3-ovirt-engine-sdk4` is required by `ovirt-ansible-roles`, I didn't explicitly require that rpm (which was being done in kickstart)