### PR TITLE
Move changelog to a separate file to allow customization

### DIFF
--- a/config/options.yml
+++ b/config/options.yml
@@ -20,6 +20,7 @@ rpm:
   org_name:        manageiq
   product_summary: ManageIQ Management Engine
   product_url:     https://github.com/ManageIQ/manageiq
+  changelog:
 bundler_version:   2.1.4
 npm_registry:
 rpm_repository:

--- a/lib/manageiq/rpm_build/build_copr.rb
+++ b/lib/manageiq/rpm_build/build_copr.rb
@@ -36,8 +36,12 @@ module ManageIQ
 
         Dir.glob("subpackages/*").sort.each do |spec|
           subpackage_spec = File.read(spec)
-          manageiq_spec.sub!("%changelog", "#{subpackage_spec}\n\n%changelog")
+          manageiq_spec << "#{subpackage_spec}\n\n"
         end
+
+        # Add changelog
+        changelog = OPTIONS.rpm.changelog ? OPTIONS_DIR.join(OPTIONS.rpm.changelog) : "changelog"
+        manageiq_spec << File.read(changelog)
 
         File.write(rpm_spec, manageiq_spec)
         update_spec

--- a/rpm_spec/changelog
+++ b/rpm_spec/changelog
@@ -1,0 +1,3 @@
+%changelog
+* Tue Apr 14 2020 Satoe Imaishi <simaishi@redhat.com> - 11.0.0-1
+- 11.0.0-1 build

--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -121,6 +121,3 @@ popd
 %clean
 rm -rf $RPM_BUILD_ROOT
 
-%changelog
-* Tue Apr 14 2020 Satoe Imaishi <simaishi@redhat.com> - 11.0.0-1
-- 11.0.0-1 build


### PR DESCRIPTION
Use with configuration override option (`-v <dir>:/root/OPTIONS`)

To use custom changelog, specify name of the changelog file in "rpm.changelog" in options.yml, and place the file along with options.yml.