### PR TITLE
Run bundle with systemd group

### DIFF
--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -61,7 +61,9 @@ module ManageIQ
 
           shell_cmd("gem env")
           shell_cmd("gem install mime-types -v 2.6.1")
-          shell_cmd("bundle _#{bundler_version}_ install --with qpid_proton --without test:development:metric_fu --jobs #{cpus} --retry 3")
+          shell_cmd("bundle config set --local with qpid_proton systemd")
+          shell_cmd("bundle config set --local without 'test:development:metric_fu'")
+          shell_cmd("bundle _#{bundler_version}_ install --jobs #{cpus} --retry 3")
 
           # Copy libsodium.so* to where rbnacl-libsodium expects
           rbnacl_libsodium_gem_dir = Pathname.new(`bundle info --path rbnacl-libsodium`.chomp)


### PR DESCRIPTION
This was added to appliance build in https://github.com/ManageIQ/manageiq-appliance-build/pull/396, but got missed when switched to rpm based. Sorry @agrare 

Also changed to use "bundle config set" to set with/without options as passing those flags
to bundle install is deprecated.