### PR TITLE
Set minimum version for rake and awesome_spawn for CVEs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'awesome_spawn'
+gem 'awesome_spawn',  ">=1.3.0"
 gem 'aws-sdk-s3'
 gem 'config'
 gem 'optimist'
-gem 'rake'
+gem 'rake',           ">=12.3.3"
 gem 'term-ansicolor'


### PR DESCRIPTION
awesome_spawn: >=1.3.0 for CVE-2014-0156
rake: >=12.3.3 for CVE-2020-8130

[Found by Hakiri](https://hakiri.io/github/ManageIQ/manageiq-rpm_build/master/c2c495c0675d7c022e80a8c4dcfb04c350f8f706/warnings?name=Command+Injection)