### PR TITLE
Add manifest for gems and npm packages

### DIFF
--- a/bin/build.rb
+++ b/bin/build.rb
@@ -30,10 +30,16 @@ ManageIQ::RPMBuild::GenerateCore.new.populate
 
 # Scrub the gemset only after it is used to generate 'core' contents
 gemset.scrub
-gemset.restore_environment_variables
 
 # Create tarballs
 ManageIQ::RPMBuild::GenerateTarFiles.new.create_tarballs
+
+# Generate manifest with license info for gems and npm packages
+gemset.generate_dependency_manifest
+gemset.restore_environment_variables
+
+# Create manifest tarball
+ManageIQ::RPMBuild::GenerateTarFiles.new.create_manifest_tarball
 
 puts "\n\nTARBALL BUILT SUCCESSFULLY"
 

--- a/lib/manageiq/rpm_build/generate_tar_files.rb
+++ b/lib/manageiq/rpm_build/generate_tar_files.rb
@@ -41,6 +41,12 @@ module ManageIQ
         shell_cmd("tar -C #{BUILD_DIR.join("manageiq")} #{transform(name)} --exclude-tag='cache/sti_loader.yml' -X #{exclude_file} -hcvzf #{tar_full_path(name)} .")
       end
 
+      def create_manifest_tarball
+        where_am_i
+
+        name = "manifest"
+        shell_cmd("tar -C #{BUILD_DIR.join(name)} #{transform(name)} --exclude='.git' -hzcf #{tar_full_path(name)} .")
+      end
       private
 
       def tar_basename(name)

--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -4,12 +4,15 @@
 %global product_url PRODUCT_URL
 
 %global app_root /var/www/miq/vmdb
-%global appliance_root /opt/%{org_name}/%{name}-appliance
-%global gemset_root /opt/%{org_name}/%{name}-gemset
+%global org_root /opt/%{org_name}
+%global appliance_root %{org_root}/%{name}-appliance
+%global gemset_root %{org_root}/%{name}-gemset
+%global manifest_root %{org_root}/manifest
 
 %global appliance_builddir %{name}-appliance-%{version}
 %global core_builddir %{name}-core-%{version}
 %global gemset_builddir %{name}-gemset-%{version}
+%global manifest_builddir %{name}-manifest-%{version}
 
 %global debug_package %{nil}
 %global __requires_exclude ^\/usr\/bin\/jruby
@@ -25,6 +28,7 @@ URL:      %{product_url}
 Source0:  %{name}-appliance-%{version}.tar.gz
 Source1:  %{name}-core-%{version}.tar.gz
 Source2:  %{name}-gemset-%{version}.tar.gz
+Source3:  %{name}-manifest-%{version}.tar.gz
 
 %description
 %{product_summary}
@@ -33,6 +37,7 @@ Source2:  %{name}-gemset-%{version}.tar.gz
 %setup -q -n %{appliance_builddir}
 %setup -q -T -D -b 1 -n %{core_builddir}
 %setup -q -T -D -b 2 -n %{gemset_builddir}
+%setup -q -T -D -b 3 -n %{manifest_builddir}
 
 # buildsubdir is set to the last extracted archive (gemset), reset
 cd %{_builddir}
@@ -80,6 +85,10 @@ cd %{_builddir}
 %{__cp} -r %{gemset_builddir}/specifications %{buildroot}%{gemset_root}
 %{__cp} -r %{gemset_builddir}/vmdb %{buildroot}%{gemset_root}
 install -m644 %{gemset_builddir}/enable %{buildroot}%{gemset_root}
+
+### from manifest
+%{__mkdir} -p %{buildroot}%{manifest_root}
+%{__cp} -r %{manifest_builddir}/* %{buildroot}%{manifest_root}
 
 # workaround
 %{__rm} -rf %{buildroot}/%{gemset_root}/gems/ffi-*/ext

--- a/rpm_spec/subpackages/manageiq-system
+++ b/rpm_spec/subpackages/manageiq-system
@@ -23,6 +23,7 @@ Requires: openldap-clients
 /root/.ansible.cfg
 %{appliance_root}
 %{app_root}/log/apache
+%{manifest_root}
 %{_bindir}/cloud_ds_check.sh
 %{_bindir}/cockpit-auth-miq
 %{_bindir}/evm*


### PR DESCRIPTION
Using license_finder gem, creates gem_manifest.csv and npm_manifest.csv in /opt/manageiq/manifest. 

A part of https://github.com/ManageIQ/manageiq-appliance-build/issues/429

I couldn't find a way to find out gem source (rubygem vs rubygems.manageiq, etc) for each gem, so that's not included. source isn't applicable to npm either.

There are other columns that can be included if needed. Available columns are: `"name", "version", "authors", "licenses", "license_links", "approved", "summary", "description", "homepage", "install_path", "package_manager", "groups", "texts", "notice"`

Currently included are: `"name", "version", "license"`

~~c493354 should be reverted once https://github.com/ManageIQ/manageiq-rpm_build/pull/62 is merged.~~. Done