### PR TITLE
Only cleanup repo files listed under directories in the config

### DIFF
--- a/config/options.yml
+++ b/config/options.yml
@@ -35,21 +35,6 @@ rpm_repository:
     - "ppc64le"
     - "x86_64"
   :content:
-    :10-jansa:
-      :targets:
-        - el8
-      :rpms:
-        :manageiq: !ruby/regexp /.+-10\.\d\.\d-\d(\.\d\.(alpha|beta)\d)?\.el.+/
-        :manageiq-release: !ruby/regexp /.+-10\.0.+/
-        :qpid-proton: !ruby/regexp /.+-0\.30\.0.+/
-        :repmgr10: !ruby/regexp /.+-4\.0\.6.+/
-        :smem: !ruby/regexp /.+-1\.5.+/
-        :wmi: !ruby/regexp /.+-1\.3\.14.+/
-    :10-jansa-nightly:
-      :targets:
-        - el8
-      :rpms:
-        :manageiq-nightly: !ruby/regexp /.+-10\.\d\.\d-\d\.\d\.\d+\.el.+/
     :11-kasparov:
       :targets:
         - el8

--- a/lib/manageiq/rpm_build/rpm_repo.rb
+++ b/lib/manageiq/rpm_build/rpm_repo.rb
@@ -61,10 +61,14 @@ module ManageIQ
 
           # Cleanup old stuff online
           puts "Cleaning old files in bucket..."
-          client.list_objects(:bucket => OPTIONS.rpm_repository.s3_api.bucket).contents.each do |object|
-            next unless object.key.start_with?("release/")
-            next if File.file?(work_dir.join(object.key))
-            client.delete_object(:bucket => OPTIONS.rpm_repository.s3_api.bucket, :key => object.key)
+          OPTIONS.rpm_repository.content.keys.each do |key|
+            prefix = File.join("release", key.to_s)
+            puts "Cleaning #{prefix}:"
+            client.list_objects(:bucket => OPTIONS.rpm_repository.s3_api.bucket, :prefix => prefix).contents.each do |object|
+              next if File.file?(work_dir.join(object.key))
+              puts "  removing #{object.key}"
+              client.delete_object(:bucket => OPTIONS.rpm_repository.s3_api.bucket, :key => object.key)
+            end
           end
         end
       end


### PR DESCRIPTION
Allow for sparse config files where we only need to maintain the repos in the config for the branch of the rpm build code

Fixes #60 