### PR TITLE
Remove pdf-writer demo directory

### DIFF
--- a/scripts/gem_cleanup.sh
+++ b/scripts/gem_cleanup.sh
@@ -22,3 +22,6 @@ find bundler/gems/**/ -maxdepth 2 -name docs -type d -exec rm -rf {} +
 # Remove node_modules
 find gems/**/ -maxdepth 2 -name node_modules -type d -exec rm -rf {} +
 find bundler/gems/**/ -maxdepth 2 -name node_modules -type d -exec rm -rf {} +
+
+# Remove files with inappropriate license
+rm -rf gems/pdf-writer-*/demo  # Creative Commons Attribution NonCommercial


### PR DESCRIPTION
pdf-writer gem 'demo' directory contains a file with non-commercial license.