### PR TITLE
Add webpack manifest

### DIFF
--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -90,6 +90,9 @@ install -m644 %{gemset_builddir}/enable %{buildroot}%{gemset_root}
 %{__mkdir} -p %{buildroot}%{manifest_root}
 %{__cp} -r %{manifest_builddir}/* %{buildroot}%{manifest_root}
 
+# Move webpack manifest
+%{__mv} %{buildroot}%{app_root}/public/packs/webpack-modules-manifest.json %{buildroot}%{manifest_root}/webpack_manifest.json
+
 # workaround
 %{__rm} -rf %{buildroot}/%{gemset_root}/gems/ffi-*/ext
 
@@ -125,7 +128,6 @@ popd
 
 #copy all files/directories below COPY
 %{__cp} -r ./%{appliance_builddir}/COPY/* %{buildroot}/
-
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/rpm_spec/subpackages/manageiq-gemset
+++ b/rpm_spec/subpackages/manageiq-gemset
@@ -50,3 +50,4 @@ Requires: network-scripts
 %{gemset_root}/specifications
 %{gemset_root}/vmdb
 %{gemset_root}/enable
+%{manifest_root}/gem_manifest.csv

--- a/rpm_spec/subpackages/manageiq-system
+++ b/rpm_spec/subpackages/manageiq-system
@@ -23,7 +23,7 @@ Requires: openldap-clients
 /root/.ansible.cfg
 %{appliance_root}
 %{app_root}/log/apache
-%{manifest_root}
+%dir %{manifest_root}
 %{_bindir}/cloud_ds_check.sh
 %{_bindir}/cockpit-auth-miq
 %{_bindir}/evm*

--- a/rpm_spec/subpackages/manageiq-ui
+++ b/rpm_spec/subpackages/manageiq-ui
@@ -11,4 +11,5 @@ Requires: httpd
 %{app_root}/public/assets
 %{app_root}/public/packs
 %{app_root}/public/ui
+%{manifest_root}/webpack_manifest.json
 %config(noreplace) %{app_root}/public/custom.css

--- a/rpm_spec/subpackages/manageiq-ui
+++ b/rpm_spec/subpackages/manageiq-ui
@@ -11,5 +11,6 @@ Requires: httpd
 %{app_root}/public/assets
 %{app_root}/public/packs
 %{app_root}/public/ui
+%{manifest_root}/npm_manifest.csv
 %{manifest_root}/webpack_manifest.json
 %config(noreplace) %{app_root}/public/custom.css


### PR DESCRIPTION
Add webpack manifest. Also moved existing manifest from manageiq-system to appropriate RPMs as it doesn't make sense to include manifest in images not used (e.g. including npm manifest in manageiq-base image)

Related PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/7180, https://github.com/ManageIQ/manageiq-appliance-build/issues/429