### PR TITLE
Ensure that the group has write access to the files and directories

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -89,6 +89,6 @@ if systemctl is-active --quiet evm-failover-monitor; then
 fi
 
 %files appliance
-%defattr(-,root,root,-)
+%defattr(-,root,root,775)
 %{_sysconfdir}/httpd/conf.d/manageiq-*
 %{_sysconfdir}/motd.manageiq

--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -34,7 +34,7 @@ done
 %{__cp} -f %{app_root}/config/cable.yml.sample %{app_root}/config/cable.yml
 
 %files core
-%defattr(-,root,root,-)
+%defattr(-,root,root,775)
 %{app_root}
 %config(noreplace) %{app_root}/certs
 %exclude %{app_root}/public/assets

--- a/rpm_spec/subpackages/manageiq-gemset
+++ b/rpm_spec/subpackages/manageiq-gemset
@@ -41,7 +41,7 @@ Requires: network-scripts
 %{product_summary} Gemset
 
 %files gemset
-%defattr(-,root,root,-)
+%defattr(-,root,root,775)
 %dir %{gemset_root}
 %{gemset_root}/bin
 %{gemset_root}/build_info

--- a/rpm_spec/subpackages/manageiq-system
+++ b/rpm_spec/subpackages/manageiq-system
@@ -18,7 +18,7 @@ Requires: openldap-clients
 %{product_summary} System
 
 %files system
-%defattr(-,root,root,-)
+%defattr(-,root,root,775)
 /.toprc
 /root/.ansible.cfg
 %{appliance_root}

--- a/rpm_spec/subpackages/manageiq-ui
+++ b/rpm_spec/subpackages/manageiq-ui
@@ -7,7 +7,7 @@ Requires: httpd
 %{product_summary} UI
 
 %files ui
-%defattr(-,root,root,-)
+%defattr(-,root,root,775)
 %{app_root}/public/assets
 %{app_root}/public/packs
 %{app_root}/public/ui


### PR DESCRIPTION
In the podified environment we found that the group did not have write permissions to the /var/www/miq/vmdb directory once the manageiq-ui RPM was installed.  This prevented us from writing the GUID and other files to disk at container start and eventually put us in a CrashBackoffLoop.  This is because Openshift runs the pod with a user id that is not root (some very high number) and root group.  So we had permission to read, but not write.  The systems building the RPMs have a umask of 0022, so I'm not sure how any of the other containers that don't include the manageiq-ui RPM are building with the correct permissions and working.  Or why this has been an intermittent issue.  I would have expected it to always fail.

The error observed was:
```
== Writing encryption key ==
/usr/local/bin/entrypoint: line 6: /var/www/miq/vmdb/certs/v2_key: Permission denied
/usr/local/bin/entrypoint: line 12: /var/www/miq/vmdb/GUID: Permission denied
/usr/share/ruby/logger.rb:752:in `initialize': Permission denied @ rb_sysopen - /var/www/miq/vmdb/log/evm.log (Errno::EACCES)
    from /usr/share/ruby/logger.rb:752:in `open'
    from /usr/share/ruby/logger.rb:752:in `create_logfile'
    from /usr/share/ruby/logger.rb:746:in `rescue in open_logfile'
    from /usr/share/ruby/logger.rb:742:in `open_logfile'
    from /usr/share/ruby/logger.rb:736:in `set_dev'
    from /usr/share/ruby/logger.rb:671:in `initialize'
    from /usr/share/ruby/logger.rb:387:in `new'
    from /usr/share/ruby/logger.rb:387:in `initialize'
    from /opt/manageiq/manageiq-gemset/bundler/gems/manageiq-gems-pending-6158fc736713/lib/gems/pending/util/vmdb-logger.rb:11:in `initialize'
    from /var/www/miq/vmdb/lib/vmdb/loggers.rb:85:in `new'
    from /var/www/miq/vmdb/lib/vmdb/loggers.rb:85:in `create_multicast_logger'
    from /var/www/miq/vmdb/lib/vmdb/loggers.rb:55:in `create_loggers'
    from /var/www/miq/vmdb/lib/vmdb/loggers.rb:18:in `init'
    from /var/www/miq/vmdb/config/application.rb:134:in `<class:Application>'
    from /var/www/miq/vmdb/config/application.rb:35:in `<module:Vmdb>'
    from /var/www/miq/vmdb/config/application.rb:34:in `<top (required)>'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /var/www/miq/vmdb/config/environment.rb:2:in `<top (required)>'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /var/www/miq/vmdb/lib/workers/bin/run_single_worker.rb:63:in `<main>'
/usr/share/ruby/logger.rb:744:in `initialize': No such file or directory @ rb_sysopen - /var/www/miq/vmdb/log/evm.log (Errno::ENOENT)
    from /usr/share/ruby/logger.rb:744:in `open'
    from /usr/share/ruby/logger.rb:744:in `open_logfile'
    from /usr/share/ruby/logger.rb:736:in `set_dev'
    from /usr/share/ruby/logger.rb:671:in `initialize'
    from /usr/share/ruby/logger.rb:387:in `new'
    from /usr/share/ruby/logger.rb:387:in `initialize'
    from /opt/manageiq/manageiq-gemset/bundler/gems/manageiq-gems-pending-6158fc736713/lib/gems/pending/util/vmdb-logger.rb:11:in `initialize'
    from /var/www/miq/vmdb/lib/vmdb/loggers.rb:85:in `new'
    from /var/www/miq/vmdb/lib/vmdb/loggers.rb:85:in `create_multicast_logger'
    from /var/www/miq/vmdb/lib/vmdb/loggers.rb:55:in `create_loggers'
    from /var/www/miq/vmdb/lib/vmdb/loggers.rb:18:in `init'
    from /var/www/miq/vmdb/config/application.rb:134:in `<class:Application>'
    from /var/www/miq/vmdb/config/application.rb:35:in `<module:Vmdb>'
    from /var/www/miq/vmdb/config/application.rb:34:in `<top (required)>'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /var/www/miq/vmdb/config/environment.rb:2:in `<top (required)>'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /var/www/miq/vmdb/lib/workers/bin/run_single_worker.rb:63:in `<main>'
```