### PR TITLE
Add s390x repo

### DIFF
--- a/config/options.yml
+++ b/config/options.yml
@@ -34,6 +34,7 @@ rpm_repository:
     - "src"
     - "noarch"
     - "ppc64le"
+    - "s390x"
     - "x86_64"
   :content:
     :11-kasparov:


### PR DESCRIPTION
Wonder if we should add a support for specifying architectures per release?

Related issue: https://github.com/ManageIQ/manageiq-rpm_build/issues/83