### PR TITLE
Add wmi only if x86_64

### DIFF
--- a/rpm_spec/subpackages/manageiq-gemset
+++ b/rpm_spec/subpackages/manageiq-gemset
@@ -14,7 +14,7 @@ Requires: openssl
 Requires: nodejs
 Requires: sqlite
 
-%ifnarch ppc64le
+%ifarch x86_64
 Requires: wmi
 %endif
 


### PR DESCRIPTION
Reversing the logic and add wmi only for specific arch (currently x86_64 only).

Related to https://github.com/ManageIQ/manageiq-rpm_build/issues/83