### PR TITLE
Include rpms only for supported arch

### DIFF
--- a/lib/manageiq/rpm_build/rpm_repo.rb
+++ b/lib/manageiq/rpm_build/rpm_repo.rb
@@ -27,6 +27,7 @@ module ManageIQ
                 name = File.basename(file)
                 *, target, arch, _rpm = name.split(".")
                 next unless values[:targets].include?(target)
+                next unless OPTIONS.rpm_repository.arches.include?(arch)
                 next unless version_regex =~ name
                 cached_rpm = ROOT_DIR.join("rpm_cache", name)
                 unless cached_rpm.file?


### PR DESCRIPTION
s390x was added only in 'master' but it was trying to include it for jansa as well, and it was failing:

```
/usr/share/ruby/fileutils.rb:1386:in `initialize': No such file or directory @ rb_sysopen - /tmp/d20200828-50-osriz7/release/10-jansa/el8/s390x/python3-qpid-proton-0.30.0-2.el8.s390x.rpm (Errno::ENOENT)
        from /usr/share/ruby/fileutils.rb:1386:in `open'
        from /usr/share/ruby/fileutils.rb:1386:in `block in copy_file'
        from /usr/share/ruby/fileutils.rb:1385:in `open'
        from /usr/share/ruby/fileutils.rb:1385:in `copy_file'
        from /usr/share/ruby/fileutils.rb:492:in `copy_file'
        from /usr/share/ruby/fileutils.rb:419:in `block in cp'
        from /usr/share/ruby/fileutils.rb:1557:in `block in fu_each_src_dest'
        from /usr/share/ruby/fileutils.rb:1573:in `fu_each_src_dest0'
        from /usr/share/ruby/fileutils.rb:1555:in `fu_each_src_dest'
        from /usr/share/ruby/fileutils.rb:418:in `cp'
        from /build_scripts/lib/manageiq/rpm_build/rpm_repo.rb:37:in `block (4 levels) in update'
        from /build_scripts/lib/manageiq/rpm_build/rpm_repo.rb:25:in `each'
        from /build_scripts/lib/manageiq/rpm_build/rpm_repo.rb:25:in `block (3 levels) in update'
        from /root/.gem/ruby/gems/config-2.2.1/lib/config/options.rb:122:in `each'
        from /root/.gem/ruby/gems/config-2.2.1/lib/config/options.rb:122:in `each'
        from /build_scripts/lib/manageiq/rpm_build/rpm_repo.rb:24:in `block (2 levels) in update'
        from /root/.gem/ruby/gems/config-2.2.1/lib/config/options.rb:122:in `each'
        from /root/.gem/ruby/gems/config-2.2.1/lib/config/options.rb:122:in `each'
        from /build_scripts/lib/manageiq/rpm_build/rpm_repo.rb:23:in `block in update'
        from /usr/share/ruby/tmpdir.rb:93:in `mktmpdir'
        from /build_scripts/lib/manageiq/rpm_build/rpm_repo.rb:9:in `update'
        from bin/build.rb:52:in `<main>'
```