### PR TITLE
Use Gemfile.lock.release (if exist) and update plugin revision for nightly build

### DIFF
--- a/bin/build.rb
+++ b/bin/build.rb
@@ -23,7 +23,7 @@ gemset = ManageIQ::RPMBuild::GenerateGemSet.new
 gemset.backup_environment_variables
 gemset.set_environment_variables
 gemset.recreate_gem_home
-gemset.populate_gem_home
+gemset.populate_gem_home(build_type)
 
 # Generate 'core' contents
 ManageIQ::RPMBuild::GenerateCore.new.populate


### PR DESCRIPTION
The expectation is that new Gemfile.lock.release gets committed to core repo if gem versions need to be updated, and this should only update plugin revision.  If that's not the case, bundle install will probably fail.

The release build will have new Gemfile.lock.release committed at time of tagging (work still in progress) and no need to update plugin revision.

With this change and jansa-1-rc2 Gemfile.lock, running a jansa nightly build updates ref/revision for plugin only. Running `bundle update --conservative` instead will update other gems as well and can't be used:

```diff
<     autoprefixer-rails (9.8.6.1)
---
>     autoprefixer-rails (9.8.6.3)
378,379c378,379
<     aws-partitions (1.354.0)
<     aws-sdk-cloudformation (1.41.0)
---
>     aws-partitions (1.363.0)
>     aws-sdk-cloudformation (1.42.0)
......
```