### PR TITLE
Replace pip install for vspk/pylxca with rpm

### DIFF
--- a/config/options.yml
+++ b/config/options.yml
@@ -44,6 +44,10 @@ rpm_repository:
         :kafka: !ruby/regexp /.+-2\.3.+/
         :manageiq: !ruby/regexp /.+-11\.\d\.\d-\d(\.\d\.(alpha|beta|rc)\d)?\.el.+/
         :manageiq-release: !ruby/regexp /.+-11\.0.+/
+        :python-bambou: !ruby/regexp /.+-3\.1\.1.+/
+        :python-pylxca: !ruby/regexp /.+-2\.1\.1.+/
+        :python-unittest2: !ruby/regexp /.+-1\.1\.0.+/
+        :python-vspk: !ruby/regexp /.+-5\.3\.2.+/
         :qpid-proton: !ruby/regexp /.+-0\.30\.0.+/
         :repmgr10: !ruby/regexp /.+-4\.0\.6.+/
         :smem: !ruby/regexp /.+-1\.5.+/

--- a/rpm_spec/subpackages/manageiq-gemset
+++ b/rpm_spec/subpackages/manageiq-gemset
@@ -23,9 +23,13 @@ Requires: OpenIPMI
 Requires: freeipmi
 Requires: ipmitool
 
+# For Lenovo
+Requires: python3-pylxca
+
 # For Nuage
 Requires: cyrus-sasl
 Requires: cyrus-sasl-plain
+Requires: python3-vspk
 Requires: qpid-proton-c
 
 # For RHV


### PR DESCRIPTION
For Lenovo: python3-pylxca
For Nuage: python3-vspk

(python3-bambou is a dependency of python3-vspk)

Also added noarch python3-unittest2 to manageiq yum repo, so we don't need to use PowerTools repo (https://github.com/ManageIQ/manageiq-pods/pull/632)

Note: what's in options.yml is the package name (e.g. python-pylxca) and what's in rpm spec is the rpm name (e.g. python3-pylxca).

Goes with https://github.com/ManageIQ/manageiq-appliance-build/pull/441