### PR TITLE
Don't set version for unf_ext gem

### DIFF
--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -66,7 +66,7 @@ module ManageIQ
 
           if RUBY_PLATFORM.match?(/powerpc64le/)
             shell_cmd("gem install sassc  -- --disable-march-tune-native")
-            shell_cmd("gem install unf_ext -v '0.0.7.2' -- --with-cxxflags='-fsigned-char'")
+            shell_cmd("gem install unf_ext -- --with-cxxflags='-fsigned-char'")
           end
 
           shell_cmd("bundle config set --local with qpid_proton systemd")


### PR DESCRIPTION
I'm not sure why unf_ext gem version was originally set to 0.0.7.2 as that version is from Feb 2016 and not the version bundle install currently picks up. Since that gem is a dependency of a dependency and open-ended, doing the same here.

This part of the code runs only on power and s390x, so I'm not able to test personally.

cc @seth-priya @dpkulkarni