### PR TITLE
Add the kafka jaas config to kafka.service

### DIFF
--- a/packages/kafka/kafka.service
+++ b/packages/kafka/kafka.service
@@ -3,6 +3,7 @@ Description=kafka service
 After=zookeeper.service
 
 [Service]
+Environment="KAFKA_OPTS=-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
 ExecStart=/opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/server.properties
 Restart=on-failure
 User=kafka


### PR DESCRIPTION
The appliance_console will be used to configure kafka. One of the things the appliance_console will do it to create the file /opt/kafka/config/kafka_server_jaas.conf. 

The /opt/kafka/config/kafka_server_jaas.conf file is introduced to the kafka service with this change.

If the /opt/kafka/config/kafka_server_jaas.conf file does not exist this change will cause the kafka server to fail to start.  This file is required and the appliance_console will need to be used to create it before the service can be started.

