### PR TITLE
Productization support for manageiq-ansible-venv

### DIFF
--- a/packages/manageiq-ansible-venv/Dockerfile
+++ b/packages/manageiq-ansible-venv/Dockerfile
@@ -2,10 +2,13 @@ FROM registry.access.redhat.com/ubi8/ubi:8.2
 
 ARG ARCH=x86_64
 
-ENV NAME=manageiq-ansible-venv \
-    VERSION=1.0.0 \
+# For productization
+ENV PRODUCT_NAME=manageiq \
+    PRODUCT_SUMMARY="ManageIQ Management Engine"
+
+ENV RPM_SPEC=manageiq-ansible-venv.spec \
     VENV_ROOT=/var/lib/manageiq \
-    RPM_SPEC=manageiq-ansible-venv.spec
+    VERSION=1.0.0
 
 # CentOS repos: rpm-build and copr-cli dependencies
 # EPEL: copr-cli

--- a/packages/manageiq-ansible-venv/README.md
+++ b/packages/manageiq-ansible-venv/README.md
@@ -19,3 +19,9 @@ Builds RPM for ManageIQ Ansible Virtualenv in a container image
   `docker run -ti manageiq/ansible_venv_rpm_build bash`
 
    Run `./build.sh` to start the build.
+
+### Productization
+
+The rpm prefix and product name can be changed during build. To productize, run with:
+
+`-e PRODUCT_NAME=<name> -e PRODUCT_SUMMARY=<summary>`

--- a/packages/manageiq-ansible-venv/container-assets/build.sh
+++ b/packages/manageiq-ansible-venv/container-assets/build.sh
@@ -3,6 +3,7 @@
 set -e
 
 venv_path=$VENV_ROOT/venv
+rpm_name=$PRODUCT_NAME-ansible-venv
 rpm_path=/root/rpms
 
 # Setup venv
@@ -18,7 +19,12 @@ rm -f $venv_path/lib64
 # Build RPM
 echo "*** Building rpm"
 mkdir -p $rpm_path
-tar -C $VENV_ROOT --transform "s,^,$NAME-$VERSION/," -zcf $rpm_path/$NAME-$VERSION.tar.gz .
+tar -C $VENV_ROOT --transform "s,^,$rpm_name-$VERSION/," -zcf $rpm_path/$rpm_name-$VERSION.tar.gz .
+
+sed -i "s/PRODUCT_NAME/$rpm_name/" $RPM_SPEC
+sed -i "s/PRODUCT_SUMMARY/$PRODUCT_SUMMARY/" $RPM_SPEC
+sed -i "s/VERSION/$VERSION/" $RPM_SPEC
+sed -i "s#VENV_ROOT#$VENV_ROOT#" $RPM_SPEC
 
 if [ -f "/root/.config/copr" ]; then
   rpmbuild -bs --define "_sourcedir $rpm_path" --define "_srcrpmdir $rpm_path" /$RPM_SPEC

--- a/packages/manageiq-ansible-venv/manageiq-ansible-venv.spec
+++ b/packages/manageiq-ansible-venv/manageiq-ansible-venv.spec
@@ -1,10 +1,12 @@
-%global app_root /var/lib/manageiq
+%global product_summary Ansible virtual environmnent for PRODUCT_SUMMARY
+
+%global app_root VENV_ROOT
 %global _python_bytecompile_extra 0
 
-Name:     manageiq-ansible-venv
-Version:  1.0.0
+Name:     PRODUCT_NAME
+Version:  VERSION
 Release:  1%{?dist}
-Summary:  ManageIQ Ansible Virtualenv
+Summary:  %{product_summary}
 License:  Apache-2.0
 URL:      https://github.com/ManageIQ/manageiq
 Source0:  %{name}-%{version}.tar.gz
@@ -13,7 +15,7 @@ AutoReqProv: no
 BuildRequires: /usr/bin/pathfix.py
 
 %description
-ManageIQ Ansible module virtual environmnent
+%{product_summary}
 
 %prep
 %setup -q


### PR DESCRIPTION
2 things can be productized:

- PRODUCT_NAME (default: manageiq)
- PRODUCT_SUMMARY (default: ManageIQ Management Engine) - used in RPM summary/description

Those are the same variables as what's used for manageiq-* rpm build, specified in config/options.yml
