### PR TITLE
Add manifest for manageiq-ansible-venv

### DIFF
--- a/packages/manageiq-ansible-venv/Dockerfile
+++ b/packages/manageiq-ansible-venv/Dockerfile
@@ -3,7 +3,8 @@ FROM registry.access.redhat.com/ubi8/ubi:8.2
 ARG ARCH=x86_64
 
 # For productization
-ENV PRODUCT_NAME=manageiq \
+ENV ORG_NAME=manageiq \
+    PRODUCT_NAME=manageiq \
     PRODUCT_SUMMARY="ManageIQ Management Engine"
 
 ENV RPM_SPEC=manageiq-ansible-venv.spec \

--- a/packages/manageiq-ansible-venv/README.md
+++ b/packages/manageiq-ansible-venv/README.md
@@ -22,6 +22,10 @@ Builds RPM for ManageIQ Ansible Virtualenv in a container image
 
 ### Productization
 
-The rpm prefix and product name can be changed during build. To productize, run with:
+The rpm prefix, rpm summary info, and org name can be changed during build. To productize, run with:
 
-`-e PRODUCT_NAME=<name> -e PRODUCT_SUMMARY=<summary>`
+`-e PRODUCT_NAME=<name> -e PRODUCT_SUMMARY=<summary> -e ORG_NAME=<org name>`
+
+ - PRODUCT_NAME = used for rpm prefix: `<name>-ansible-venv`, should match `product_name` in config/options.yml for manageiq RPMs, default: manageiq
+ - PRODUCT_SUMMARY = used for rpm summary/description, default: ManageIQ Management Engine
+ - ORG_NAME = used for manifest path: `/opt/<org name>/manifest`, should match `rpm.org_name` in config/options.yml for manageiq RPMs, default: manageiq

--- a/packages/manageiq-ansible-venv/container-assets/build.sh
+++ b/packages/manageiq-ansible-venv/container-assets/build.sh
@@ -10,7 +10,14 @@ rpm_path=/root/rpms
 echo "*** Setting up venv"
 python3 -m venv $venv_path
 source $venv_path/bin/activate
+
 pip3 install --no-compile -r $VENV_ROOT/requirements.txt
+
+# Generate manifest
+pip3 install pip-licenses
+pip-licenses --from=mixed --format=csv --output-file=$VENV_ROOT/ansible_venv_manifest.csv
+pip3 uninstall -y pip-licenses PTable
+
 deactivate
 
 # Build RPM
@@ -20,6 +27,7 @@ mkdir -p $rpm_path
 tar -C $VENV_ROOT --transform "s,^,$rpm_name-$VERSION/," --exclude='venv/bin/python' --exclude='venv/bin/python3' --exclude='venv/lib64' \
     -zcf $rpm_path/$rpm_name-$VERSION.tar.gz .
 
+sed -i "s/ORG_NAME/$ORG_NAME/" $RPM_SPEC
 sed -i "s/PRODUCT_NAME/$rpm_name/" $RPM_SPEC
 sed -i "s/PRODUCT_SUMMARY/$PRODUCT_SUMMARY/" $RPM_SPEC
 sed -i "s/VERSION/$VERSION/" $RPM_SPEC

--- a/packages/manageiq-ansible-venv/manageiq-ansible-venv.spec
+++ b/packages/manageiq-ansible-venv/manageiq-ansible-venv.spec
@@ -1,6 +1,7 @@
 %global product_summary Ansible virtual environmnent for PRODUCT_SUMMARY
-
 %global app_root VENV_ROOT
+%global manifest_root /opt/ORG_NAME/manifest
+
 %global _python_bytecompile_extra 0
 
 Name:     PRODUCT_NAME
@@ -25,6 +26,9 @@ pathfix.py -pni "%{__python3} %{py3_shbang_opts}" .
 %{__mkdir} -p %{buildroot}%{app_root}
 %{__cp} -r . %{buildroot}%{app_root}
 
+%{__mkdir} -p %{buildroot}%{manifest_root}
+%{__mv} %{buildroot}/%{app_root}/ansible_venv_manifest.csv %{buildroot}%{manifest_root}
+
 ln -s %{app_root}/venv/lib %{buildroot}%{app_root}/venv/lib64
 ln -s %{__python3} %{buildroot}%{app_root}/venv/bin/python3
 ln -s %{app_root}/venv/bin/python3 %{buildroot}%{app_root}/venv/bin/python
@@ -35,6 +39,7 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %defattr(-,root,root,-)
 %{app_root}
+%{manifest_root}/ansible_venv_manifest.csv
 
 %changelog
 * Wed Oct 7 2020 Satoe Imaishi <simaishi@redhat.com> - 1.0.0-1


### PR DESCRIPTION
Creates `/opt/manageiq/manifest/ansible_venv_manifest.csv` for python modules included in manageiq-ansible-venv.

A part of https://github.com/ManageIQ/manageiq-appliance-build/issues/429

Sample manifest:
```
"Name","Version","License"
"Jinja2","2.10.1","BSD License"
"MarkupSafe","1.1.1","BSD License"
"PyJWT","1.7.1","MIT License"
"PyNaCl","1.4.0","Apache License 2.0"
....
```