### PR TITLE
DNF command cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN if [ ${ARCH} != "s390x" ] ; then dnf -y install http://mirror.centos.org/cen
     dnf -y module enable nodejs:12 && \
     dnf -y module disable virt:rhel && \
     dnf -y group install "development tools" && \
-    dnf config-manager --setopt=epel.exclude=*qpid-proton* --save && \
-    dnf -y --setopt=tsflags=nodocs install \
+    dnf config-manager --setopt=epel.exclude=*qpid-proton* --setopt=tsflags=nodocs --save && \
+    dnf -y install \
       ansible \
       cmake \
       copr-cli \
@@ -39,7 +39,8 @@ RUN if [ ${ARCH} != "s390x" ] ; then dnf -y install http://mirror.centos.org/cen
       ruby-devel \
       rubygem-bundler \
       sqlite-devel \
-      wget
+      wget && \
+    dnf clean all
 
 RUN if [ ${ARCH} = "s390x" ] || [ ${ARCH} = "ppc64le" ] ; then dnf -y install python2 ; fi
 

--- a/packages/manageiq-ansible-venv/Dockerfile
+++ b/packages/manageiq-ansible-venv/Dockerfile
@@ -12,11 +12,13 @@ ENV RPM_SPEC=manageiq-ansible-venv.spec \
 
 # CentOS repos: rpm-build and copr-cli dependencies
 # EPEL: copr-cli
-RUN dnf -y --disableplugin=subscription-manager install \
+RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/subscription-manager.conf
+RUN dnf -y install \
       http://mirror.centos.org/centos/8.2.2004/BaseOS/${ARCH}/os/Packages/centos-repos-8.2-2.2004.0.1.el8.${ARCH}.rpm \
       http://mirror.centos.org/centos/8.2.2004/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8.2-2.2004.0.1.el8.noarch.rpm \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
-    dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
+    dnf config-manager --setopt=tsflags=nodocs --save && \
+    dnf -y install \
       copr-cli \
       gcc \
       libcurl-devel \
@@ -26,11 +28,12 @@ RUN dnf -y --disableplugin=subscription-manager install \
       python3-virtualenv \
       rpm-build && \
     if [ ${ARCH} = "ppc64le" ] ; then \
-      dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
+      dnf -y install \
         libffi-devel \
         libxslt-devel \
         make ; \
-      fi
+    fi && \
+    dnf clean all
 
 COPY $RPM_SPEC container-assets/build.sh /
 COPY requirements.txt $VENV_ROOT/


### PR DESCRIPTION
- Add 'dnf clean all' command
- Handle subscription-manager disable globally for manageiq-ansible-venv (already done for rpm build container image in #97)
- Set nodocs option globally