### PR TITLE
[WIP] Add manageiq-ansible-venv rpm 'require' in manageiq-core

### DIFF
--- a/config/options.yml
+++ b/config/options.yml
@@ -44,6 +44,7 @@ rpm_repository:
         :kafka: !ruby/regexp /.+-2\.3.+/
         :manageiq: !ruby/regexp /.+-12\.\d\.\d-\d(\.\d\.(alpha|beta|rc)\d)?\.el.+/
         :manageiq-release: !ruby/regexp /.+-12\.0.+/
+        :manageiq-ansible-venv: !ruby/regexp /.+-1\.0\.0.+/
         :python-bambou: !ruby/regexp /.+-3\.1\.1.+/
         :python-pylxca: !ruby/regexp /.+-2\.1\.1.+/
         :python-unittest2: !ruby/regexp /.+-1\.1\.0.+/

--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -3,6 +3,7 @@ Summary:  %{product_summary} Core
 
 Requires: ruby
 Requires: %{name}-gemset = %{version}-%{release}
+Requires: %{name}-ansible-venv
 
 Requires: ansible
 Requires: ansible-runner


### PR DESCRIPTION
Depends on: build RPMs for supported architectures

I'm assuming the rpm prefix for the ansible venv will match the prefix for the other rpms (gemset, core, etc.)

A part of https://github.com/ManageIQ/manageiq-appliance-build/issues/423