### PR TITLE
Ensure updates to server and zookeeper properties are in config-sample

### DIFF
--- a/packages/kafka/kafka.spec
+++ b/packages/kafka/kafka.spec
@@ -62,9 +62,9 @@ rm -rf bin/windows
 cp LICENSE %{buildroot}%{kafka_home}
 cp NOTICE %{buildroot}%{kafka_home}
 cp -r bin %{buildroot}%{kafka_home}
-cp -r config %{buildroot}%{kafka_home}/config-sample
 sed "s,log.dirs=.*,log.dirs=%{_sharedstatedir}/kafka," config/server.properties > %{buildroot}%{kafka_home}/config/server.properties
 sed "s,dataDir=.*,dataDir=%{_sharedstatedir}/zookeeper," config/zookeeper.properties > %{buildroot}%{kafka_home}/config/zookeeper.properties
+cp -r config %{buildroot}%{kafka_home}/config-sample
 cp config/log4j.properties %{buildroot}%{kafka_home}/config
 cp -n */build/libs/* %{buildroot}%{kafka_home}/libs
 cp -n */build/dependant-libs*/* %{buildroot}%{kafka_home}/libs


### PR DESCRIPTION
This change ensures the server.properties and zookeeper.properties files stored in the config-sample directory will include modifications made to these files in this spec.