### PR TITLE
Allow bundler to do the install with the correct build options

### DIFF
--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -65,8 +65,8 @@ module ManageIQ
           shell_cmd("gem install mime-types -v 2.6.1")
 
           if RUBY_PLATFORM.match?(/powerpc64le|s390x/)
-            shell_cmd("gem install sassc  -- --disable-march-tune-native")
-            shell_cmd("gem install unf_ext -- --with-cxxflags='-fsigned-char'")
+            shell_cmd("bundle config set build.sassc --disable-march-tune-native")
+            shell_cmd("bundle config set build.unf_ext --with-cxxflags='-fsigned-char'")
           end
 
           shell_cmd("bundle config set --local with qpid_proton systemd")


### PR DESCRIPTION
A recent issue was found where these install commands would install the
latest version, and then bundler would resolve to a different version.
Instead of pre-installing, we can let bundler know what options to use
and let it install whatever version is feels is correct.

@simaishi Please review.  I have not tested an actual build with this yet.  Additionally, I'm not sure if this should be --local --global or something else.