### PR TITLE
Add libsodium-devel for the appliance_console

### DIFF
--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -79,13 +79,6 @@ module ManageIQ
 
           shell_cmd("bundle _#{bundler_version}_ install --jobs #{cpus} --retry 3")
 
-          # Copy libsodium.so* to where rbnacl-libsodium expects
-          # https://github.com/RubyCrypto/rbnacl-libsodium/issues/25
-          rbnacl_libsodium_gem_dir = Pathname.new(`bundle info --path rbnacl-libsodium`.chomp)
-          libsodium_library_dir    = "#{rbnacl_libsodium_gem_dir}/vendor/libsodium/dist/lib"
-          FileUtils.mkdir_p(libsodium_library_dir)
-          FileUtils.cp(Dir[rbnacl_libsodium_gem_dir.join("tmp/x86_64-linux/stage/vendor/libsodium/dist/lib/libsodium.so*")], libsodium_library_dir)
-
           # https://github.com/ManageIQ/manageiq/pull/17886
           FileUtils.mkdir("log") unless Dir.exists?("log")
 
@@ -169,11 +162,6 @@ module ManageIQ
 
           # Vendored libgit2 isn't needed once the gem is compiled
           FileUtils.rm_rf(Dir.glob("gems/rugged-*/vendor"))
-
-          # Vendored libsodium isn't needed once the gem is compiled
-          # with execeptio of dist/lib/.so files which are not copied to extensions dir
-          FileUtils.rm_rf(Dir.glob("gems/rbnacl-libsodium-*/vendor/libsodium/*").reject{|f| f.end_with?("/dist")})
-          FileUtils.rm_rf(Dir.glob("gems/rbnacl-libsodium-*/tmp"))
 
           # Remove files with inappropriate license
           FileUtils.rm_rf(Dir.glob("gems/pdf-writer-*/demo")) # Creative Commons Attribution NonCommercial

--- a/rpm_spec/subpackages/manageiq-gemset
+++ b/rpm_spec/subpackages/manageiq-gemset
@@ -39,8 +39,8 @@ Requires: ovirt-ansible-roles
 Requires: v2v-conversion-host-ansible
 
 # For Appliance Console
-Requires: network-scripts
 Requires: libsodium-devel
+Requires: network-scripts
 
 %description gemset
 %{product_summary} Gemset

--- a/rpm_spec/subpackages/manageiq-gemset
+++ b/rpm_spec/subpackages/manageiq-gemset
@@ -40,6 +40,7 @@ Requires: v2v-conversion-host-ansible
 
 # For Appliance Console
 Requires: network-scripts
+Requires: libsodium-devel
 
 %description gemset
 %{product_summary} Gemset


### PR DESCRIPTION
see: https://github.com/RubyCrypto/rbnacl-libsodium#discontinued

@Fryguy, @agrare, @gtanzillo and @simaishi This will  add the libsodium-devel RPM to go with:
https://github.com/ManageIQ/manageiq-appliance_console/pull/134