### PR TITLE
Replace ovirt-ansible-roles with ovirt-ansible-collection

### DIFF
--- a/rpm_spec/subpackages/manageiq-gemset
+++ b/rpm_spec/subpackages/manageiq-gemset
@@ -33,7 +33,7 @@ Requires: python3-vspk
 Requires: qpid-proton-c
 
 # For RHV
-Requires: ovirt-ansible-roles
+Requires: ovirt-ansible-collection
 
 # For IMS
 Requires: v2v-conversion-host-ansible


### PR DESCRIPTION
appliance/podified build is failing due to oVirt moving ansible roles into oVirt Ansible Collection:

```
Error:
 Problem 1: package manageiq-gemset-12.0.0-0.1.20201110010332.el8.x86_64 requires ovirt-ansible-roles, but none of the providers can be installed
  - package ovirt-ansible-collection-1.2.1-1.el8.noarch obsoletes ovirt-ansible-roles provided by ovirt-ansible-roles-1.2.3-1.el8.noarch
```


`ovirt-ansible-collection` rpm replaces all other ovirt-ansible-* rpms:

```
Installing dependencies:
 ovirt-ansible-collection                  noarch                  1.2.1-1.el8                                    ovirt-4.4                     276 k
     replacing  ovirt-ansible-cluster-upgrade.noarch 1.2.3-1.el8
     replacing  ovirt-ansible-disaster-recovery.noarch 1.3.0-1.el8
     replacing  ovirt-ansible-engine-setup.noarch 1.2.4-1.el8
     replacing  ovirt-ansible-hosted-engine-setup.noarch 1.1.8-1.el8
     replacing  ovirt-ansible-image-template.noarch 1.2.2-1.el8
     replacing  ovirt-ansible-infra.noarch 1.2.2-1.el8
     replacing  ovirt-ansible-manageiq.noarch 1.2.1-1.el8
     replacing  ovirt-ansible-repositories.noarch 1.2.5-1.el8
     replacing  ovirt-ansible-roles.noarch 1.2.3-1.el8
     replacing  ovirt-ansible-shutdown-env.noarch 1.1.0-1.el8
     replacing  ovirt-ansible-vm-infra.noarch 1.2.3-1.el8
```
I verified the installation works, but didn't actually test those roles still work like before...

cc @bennett-white