### PR TITLE
Update the yum repos for s390x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV TERM=xterm \
     APPLIANCE=true \
     RAILS_USE_MEMORY_STORE=true
 
+RUN if [ ${ARCH} = "s390x" ] ; then dnf update -y ; fi
 RUN curl -L https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo > /etc/yum.repos.d/ansible-runner.repo
 
 RUN dnf -y --disableplugin=subscription-manager install http://mirror.centos.org/centos/8.2.2004/BaseOS/${ARCH}/os/Packages/centos-repos-8.2-2.2004.0.1.el8.${ARCH}.rpm \


### PR DESCRIPTION
Without the dnf update command for s390x the build fails with the below error:
```
Unable to resolve argument virt:rhel
Error: Problems in request:
missing groups or modules: virt:rhel
The command '/bin/sh -c if [ ${ARCH} != "s390x" ] ; then dnf -y install http://mirror.centos.org/centos/8.2.2004/BaseOS/${ARCH}/os/Packages/centos-repos-8.2-2.2004.0.1.el8.${ARCH}.rpm                                                     http://mirror.centos.org/centos/8.2.2004/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8.2-2.2004.0.1.el8.noarch.rpm; fi &&     dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm                    https://rpm.manageiq.org/release/12-lasker/el8/noarch/manageiq-release-12.0-1.el8.noarch.rpm &&     dnf -y module enable ruby:2.6 &&     dnf -y module enable nodejs:12 &&     dnf -y module disable virt:rhel &&     dnf -y group install "development tools" &&     dnf config-manager --setopt=epel.exclude=*qpid-proton* --setopt=tsflags=nodocs --save &&     dnf -y install       ansible       cmake       copr-cli       createrepo       glibc-langpack-en       libcurl-devel       libpq-devel       libssh2-devel       libxml2-devel       libxslt-devel       nodejs       openssl-devel       platform-python-devel       postgresql-server       postgresql-server-devel       qpid-proton-c-devel       ruby-devel       rubygem-bundler       sqlite-devel       wget &&     dnf clean all' returned a non-zero code: 1
```