### PR TITLE
Add librdkafka RPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN if [ ${ARCH} != "s390x" ] ; then dnf -y install http://mirror.centos.org/cen
       glibc-langpack-en \
       libcurl-devel \
       libpq-devel \
+      librdkafka \
       libssh2-devel \
       libxml2-devel \
       libxslt-devel \

--- a/rpm_spec/subpackages/manageiq-gemset
+++ b/rpm_spec/subpackages/manageiq-gemset
@@ -5,6 +5,7 @@ BuildRequires: /usr/bin/pathfix.py
 Requires: cifs-utils
 Requires: libpq
 Requires: libcurl
+Requires: librdkafka
 Requires: libssh2
 Requires: libxml2
 Requires: libxslt


### PR DESCRIPTION
This is part of the solution for:
ManageIQ/manageiq-appliance-build#456

When gem `rdkafka` is installed/built SSL support will not be built in unless the librdkafka RPM is installed.

This PR will add the librdkafka RPM which will ensure the rdkafka gem is installed with SSL support.