### PR TITLE
Fix rpm 'release' floating addition

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ task :release do
   options = root.join("config", "options.yml")
   content = YAML.load_file(options)
   current_release = content.fetch_path("rpm", "release")
-  new_release = milestone ? current_release + 0.1 : 1
+  new_release = milestone ? (current_release + 0.1).round(1) : 1
 
   content.store_path("rpm", "version", new_version)
   content.store_path("rpm", "release", new_release)


### PR DESCRIPTION
Didn't realize 0.2 + 0.1 isn't 0.3, but it's 0.30000000000000004...