### PR TITLE
Do not copy all files from vmdb 'bin' directory

### DIFF
--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -94,7 +94,9 @@ module ManageIQ
           FileUtils.cp(miq_dir.join(".bundle/config"), GEM_HOME.join("vmdb/.bundle"))
           FileUtils.cp_r(miq_dir.join(".bundle/plugin"), GEM_HOME.join("vmdb/.bundle/"))
           FileUtils.cp(miq_dir.join("Gemfile.lock"), GEM_HOME.join("vmdb"))
-          FileUtils.cp(Dir[miq_dir.join("bin/*")], GEM_HOME.join("vmdb/bin"))
+          FileUtils.cp(miq_dir.join("bin/bundle"), GEM_HOME.join("vmdb/bin/"))
+          FileUtils.cp(miq_dir.join("bin/rails"), GEM_HOME.join("vmdb/bin/"))
+          FileUtils.cp(miq_dir.join("bin/rake"), GEM_HOME.join("vmdb/bin/"))
 
           link_git_gems
         end


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/20984 added a new directory "ci" to vmdb/bin and that's causing `cp` error during gemset generation as the code wasn't expecting a directory.

```
/usr/share/ruby/fileutils.rb:1387:in `copy_stream': Is a directory - read (Errno::EISDIR)
        from /usr/share/ruby/fileutils.rb:1387:in `block (2 levels) in copy_file'
        ....
        from /usr/share/ruby/fileutils.rb:418:in `cp'
        from /build_scripts/lib/manageiq/rpm_build/generate_gemset.rb:97:in `block in populate_gem_home'
        from /build_scripts/lib/manageiq/rpm_build/generate_gemset.rb:60:in `chdir'
        from /build_scripts/lib/manageiq/rpm_build/generate_gemset.rb:60:in `populate_gem_home'
        from bin/build.rb:26:in `<main>'
```

Changing to include what (I think) will be needed/useful on production appliances:
* Included: bundle, rails and rake
* Exluded: "ci" directory, eslint, setup and update