### PR TITLE
Add libsodium-devel to rpm_build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN if [ ${ARCH} != "s390x" ] ; then dnf -y install http://mirror.centos.org/cen
       libcurl-devel \
       libpq-devel \
       librdkafka \
+      libsodium-devel \
       libssh2-devel \
       libxml2-devel \
       libxslt-devel \


### PR DESCRIPTION
```
rake aborted!
LoadError: Could not open library 'sodium': sodium: cannot open shared object file: No such file or directory.
Could not open library 'libsodium.so': libsodium.so: cannot open shared object file: No such file or directory
/root/BUILD/manageiq-gemset-12.0.0/gems/ffi-1.14.2/lib/ffi/library.rb:145:in `block in ffi_lib'
...
/root/BUILD/manageiq-gemset-12.0.0/gems/rbnacl-4.0.2/lib/rbnacl/sodium.rb:14:in `extended'
...
/root/BUILD/manageiq-gemset-12.0.0/gems/jwt-2.2.2/lib/jwt/signature.rb:12:in `<top (required)>'
...
/root/BUILD/manageiq-gemset-12.0.0/gems/ibm_cloud_sdk_core-1.1.2/lib/ibm_cloud_sdk_core/token_managers/jwt_token_manager.rb:5:in `<top (required)>'
...
/root/BUILD/manageiq-gemset-12.0.0/gems/ibm_vpc-0.1.0/lib/ibm_vpc.rb:4:in `<top (required)>'
...
/root/BUILD/manageiq-gemset-12.0.0/bundler/gems/manageiq-providers-ibm_cloud-bfe2f0674c7e/lib/manageiq/providers/ibm_cloud/cloud_tools.rb:4:in `<top (required)>'
...
```