### PR TITLE
glusterfs-fuse is required for scanning GlusterFS datastores

### DIFF
--- a/rpm_spec/subpackages/manageiq-gemset
+++ b/rpm_spec/subpackages/manageiq-gemset
@@ -43,6 +43,9 @@ Requires: v2v-conversion-host-ansible
 Requires: libsodium-devel
 Requires: network-scripts
 
+# For scanning
+Requires: glusterfs-fuse
+
 %description gemset
 %{product_summary} Gemset
 


### PR DESCRIPTION
Pulled from https://github.com/ManageIQ/manageiq-appliance-build/pull/462