### PR TITLE
Use properties file for environmental variables

### DIFF
--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -48,13 +48,11 @@ pathfix.py -pni "%{__python3} %{py3_shbang_opts}" %{gemset_builddir}
 cd %{_builddir}
 
 cat <<"EOF" > %{appliance_builddir}/LINK/etc/default/manageiq-productizaton.properties
-APPLIANCE="true"
-BUNDLE_GEMFILE=%{app_root}/Gemfile
+APPLIANCE_SOURCE_DIRECTORY=%{appliance_root}
+APPLIANCE_TEMPLATE_DIRECTORY=%{appliance_root}/TEMPLATE
 GEM_HOME=%{gemset_root}
 GEM_PATH=%{gemset_root}:/usr/share/gems:/usr/local/share/gems
 PATH=%{gemset_root}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-APPLIANCE_SOURCE_DIRECTORY=%{appliance_root}
-APPLIANCE_TEMPLATE_DIRECTORY=%{appliance_root}/TEMPLATE
 EOF
 
 %install

--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -47,18 +47,14 @@ pathfix.py -pni "%{__python3} %{py3_shbang_opts}" %{gemset_builddir}
 %build
 cd %{_builddir}
 
-cat <<"EOF" > %{gemset_builddir}/enable
-export APPLIANCE="true"
-export BUNDLE_GEMFILE=%{app_root}/Gemfile
-export GEM_HOME=%{gemset_root}
-export GEM_PATH=%{gemset_root}:/usr/share/gems:/usr/local/share/gems
-export PATH=%{gemset_root}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-EOF
-
-cat <<"EOF" > %{appliance_builddir}/LINK/etc/default/evm_production
-export APPLIANCE_SOURCE_DIRECTORY=%{appliance_root}
-export APPLIANCE_TEMPLATE_DIRECTORY=%{appliance_root}/TEMPLATE
-source %{gemset_root}/enable
+cat <<"EOF" > %{appliance_builddir}/LINK/etc/default/manageiq-productizaton.properties
+APPLIANCE="true"
+BUNDLE_GEMFILE=%{app_root}/Gemfile
+GEM_HOME=%{gemset_root}
+GEM_PATH=%{gemset_root}:/usr/share/gems:/usr/local/share/gems
+PATH=%{gemset_root}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+APPLIANCE_SOURCE_DIRECTORY=%{appliance_root}
+APPLIANCE_TEMPLATE_DIRECTORY=%{appliance_root}/TEMPLATE
 EOF
 
 %install
@@ -85,7 +81,6 @@ cd %{_builddir}
 %{__cp} -r %{gemset_builddir}/gems %{buildroot}%{gemset_root}
 %{__cp} -r %{gemset_builddir}/specifications %{buildroot}%{gemset_root}
 %{__cp} -r %{gemset_builddir}/vmdb %{buildroot}%{gemset_root}
-install -m644 %{gemset_builddir}/enable %{buildroot}%{gemset_root}
 
 # Copy systemd unit files
 %{__mkdir} -p %{buildroot}%{_prefix}/lib/systemd/system

--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -51,13 +51,13 @@ cat <<"EOF" > %{gemset_builddir}/enable
 export APPLIANCE="true"
 export BUNDLE_GEMFILE=%{app_root}/Gemfile
 export GEM_HOME=%{gemset_root}
-export GEM_PATH=%{gemset_root}:$(gem env path)
-export PATH=%{gemset_root}/bin:$PATH
+export GEM_PATH=%{gemset_root}:/usr/share/gems:/usr/local/share/gems
+export PATH=%{gemset_root}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 EOF
 
 cat <<"EOF" > %{appliance_builddir}/LINK/etc/default/evm_production
 export APPLIANCE_SOURCE_DIRECTORY=%{appliance_root}
-export APPLIANCE_TEMPLATE_DIRECTORY=${APPLIANCE_SOURCE_DIRECTORY}/TEMPLATE
+export APPLIANCE_TEMPLATE_DIRECTORY=%{appliance_root}/TEMPLATE
 source %{gemset_root}/enable
 EOF
 

--- a/rpm_spec/subpackages/manageiq-gemset
+++ b/rpm_spec/subpackages/manageiq-gemset
@@ -60,5 +60,4 @@ Requires: glusterfs-fuse
 %{gemset_root}/gems
 %{gemset_root}/specifications
 %{gemset_root}/vmdb
-%{gemset_root}/enable
 %{manifest_root}/gem_manifest.csv

--- a/rpm_spec/subpackages/manageiq-system
+++ b/rpm_spec/subpackages/manageiq-system
@@ -40,7 +40,8 @@ Requires: openldap-clients
 %{_sysconfdir}/cloud/cloud.cfg.d/10_miq_*.cfg
 %{_sysconfdir}/cron.hourly/miq*
 %{_sysconfdir}/cron.hourly/pg-inpsector-server-hourly.cron
-%{_sysconfdir}/default/evm*
+%{_sysconfdir}/default/evm
+%{_sysconfdir}/default/manage*.properties
 %{_sysconfdir}/issue.template
 %{_sysconfdir}/logrotate.d/miq_logs.conf
 %{_sysconfdir}/manageiq/postgresql.conf.d/01_miq_overrides.conf


### PR DESCRIPTION
related to https://github.com/ManageIQ/manageiq-appliance/pull/309

for all our environments to work, we standard environment variables set
The current format is only accessible to bash scripts.

This change converts our scripts to properties files
so they are accessible to bash and systemd as well.

After this change, `source /etc/defaults/evm` still sets and exports
the same variables to the same values as before