### PR TITLE
[WIP] remove watchdog

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -61,7 +61,7 @@ if posix.access('/bin/evmserver.sh', 'x') then
   if ( pid == -1 ) then
     print ("The fork failed.")
   elseif ( pid == 0 ) then
-    posix.exec('/bin/evmserver.sh', 'update_stop')
+    posix.exec('/bin/evmserver.sh', 'stop')
   else
     posix.wait(pid)
   end
@@ -73,7 +73,7 @@ if posix.access('/bin/evmserver.sh', 'x') then
   if ( pid == -1 ) then
     print ("The fork failed.")
   elseif ( pid == 0 ) then
-    posix.exec('/bin/evmserver.sh', 'update_start')
+    posix.exec('/bin/evmserver.sh', 'start')
   else
     posix.wait(pid)
   end


### PR DESCRIPTION
part of a few PRs:

- https://github.com/ManageIQ/manageiq/pull/21146
- https://github.com/ManageIQ/manageiq-appliance/pull/311

don't run evmserver `update_stop` in rpm update. running `stop` instead.

we are getting out of the business of running a watchdog service