### PR TITLE
Fix issue where ActiveSupport could not load

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 desc "Release a new project version"
 task :release do
+  require 'active_support'
   require 'active_support/core_ext'
   require 'more_core_extensions/core_ext/hash/nested'
   require 'pathname'


### PR DESCRIPTION
Without this change, release errors with
`NameError: uninitialized constant ActiveSupport::Autoload`

@bdunne Please review.