### PR TITLE
Don't attempt to pull rpm* packages from ubi-8 repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN if [ ${ARCH} != "s390x" ] ; then dnf -y install http://mirror.centos.org/cen
     dnf -y module enable ruby:2.6 && \
     dnf -y module enable nodejs:12 && \
     dnf -y module disable virt:rhel && \
+    dnf config-manager --setopt=ubi-8-*.exclude=rpm* --save && \
     dnf -y group install "development tools" && \
     dnf config-manager --setopt=epel.exclude=*qpid-proton* --setopt=tsflags=nodocs --save && \
     dnf -y install \


### PR DESCRIPTION
For some reason we get a conflict that dnf can't resolve with only some of the rpms available at 4.14.3-13
```
Problem: package rpm-sign-4.14.3-4.el8.ppc64le requires rpm-build-libs(ppc-64) = 4.14.3-4.el8, but none of the providers can be installed
  - package rpm-build-libs-4.14.3-4.el8.ppc64le requires rpm-libs(ppc-64) = 4.14.3-4.el8, but none of the providers can be installed
  - package rpm-libs-4.14.3-4.el8.ppc64le requires rpm = 4.14.3-4.el8, but none of the providers can be installed
  - cannot install both rpm-4.14.3-13.el8.ppc64le and rpm-4.14.3-4.el8.ppc64le
  - package rpm-build-4.14.3-13.el8.ppc64le requires rpm = 4.14.3-13.el8, but none of the providers can be installed
  - cannot install the best candidate for the job
  - conflicting requests
```