### PR TITLE
create manageiq user and fix directories

### DIFF
--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -34,6 +34,7 @@ Source3:  %{name}-manifest-%{version}.tar.gz
 %{product_summary}
 
 %prep
+umask 0002
 %setup -q -n %{appliance_builddir}
 %setup -q -T -D -b 1 -n %{core_builddir}
 %setup -q -T -D -b 2 -n %{gemset_builddir}
@@ -61,12 +62,19 @@ cd %{_builddir}
 ### from core
 %{__mkdir} -p %{buildroot}%{app_root}
 %{__cp} -r %{core_builddir}/* %{buildroot}%{app_root}
+%{__chmod} 2770 %{buildroot}%{app_root}/certs
 
 ### from appliance
 %{__mkdir} -p %{buildroot}%{appliance_root}
 %{__cp} -r %{appliance_builddir}/* %{buildroot}%{appliance_root}
 %{__mkdir} -p %{buildroot}/etc/httpd/conf.d
 %{__mkdir} -p %{buildroot}%{app_root}/log/apache
+%{__mkdir} -p %{buildroot}%{app_root}/tmp/{,sockets,pids}
+%{__mkdir} -p %{buildroot}%{app_root}/{certs,config}
+%{__mkdir} -p %{buildroot}%{app_root}/public/pictures
+%{__chmod} 2770 %{buildroot}%{app_root}/{log,config,certs}
+%{__chmod} 770 %{buildroot}%{app_root}/tmp/{,pids,sockets}
+%{__chmod} 775 %{buildroot}%{app_root}/public/pictures
 
 ### from gemset
 %{__mkdir} -p %{buildroot}%{gemset_root}

--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -93,6 +93,6 @@ if systemctl is-active --quiet evm-failover-monitor; then
 fi
 
 %files appliance
-%defattr(-,root,root,775)
+%defattr(-,root,root,-)
 %{_sysconfdir}/httpd/conf.d/manageiq-*
 %{_sysconfdir}/motd.manageiq

--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -18,6 +18,10 @@ Requires: socat
 %description core
 %{product_summary} Core
 
+%pre core
+# ensure this user exists (build and upgrade)
+/usr/bin/id manageiq > /dev/null 2>&1 || /usr/sbin/useradd --system manageiq && /usr/sbin/usermod -aG manageiq root
+
 %posttrans core
 # 'bin' needs to be copied, not symlinked
 [[ -e /var/www/miq/vmdb/bin ]] && rm -rf /var/www/miq/vmdb/bin
@@ -32,11 +36,25 @@ done
 
 %post core
 %{__cp} -f %{app_root}/config/cable.yml.sample %{app_root}/config/cable.yml
+# These files are not owned by the rpm.
+#  For upgrades, ensure they have the correct group privs
+#  so root and manageiq users can read them.
+%{__chgrp} manageiq %{app_root}/certs/v2_key %{app_root}/log/*.log
+%{__chgrp} manageiq %{app_root}/tmp/pids/*.pid %{app_root}/config/*.yml
+%{__chmod} g+r,o-rw %{app_root}/certs/v2_key
+%{__chmod} g+r,o-rw %{app_root}/config/*.yml %{app_root}/tmp/pids/*.pid
+%{__chmod} g+rw %{app_root}/log/*.log
 
 %files core
-%defattr(-,root,root,775)
+%defattr(-,root,root,-)
 %{app_root}
 %config(noreplace) %{app_root}/certs
+%attr(-,-,manageiq) %{app_root}/certs
+%attr(-,-,manageiq) %{app_root}/config
+%attr(-,-,manageiq) %{app_root}/log
+%attr(-,-,manageiq) %{app_root}/tmp
+%exclude %{app_root}/public/pictures
 %exclude %{app_root}/public/assets
 %exclude %{app_root}/public/packs
 %exclude %{app_root}/public/ui
+%exclude %{app_root}/log/apache

--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -53,6 +53,9 @@ done
 %attr(-,-,manageiq) %{app_root}/config
 %attr(-,-,manageiq) %{app_root}/log
 %attr(-,-,manageiq) %{app_root}/tmp
+# this is until we fix the code that auto writes this
+# give kbrock a hard time if it is 2022 and this is still in here
+%attr(0664,-,-) %{app_root}/tmp/cache/sti_loader.yml
 %exclude %{app_root}/public/pictures
 %exclude %{app_root}/public/assets
 %exclude %{app_root}/public/packs

--- a/rpm_spec/subpackages/manageiq-gemset
+++ b/rpm_spec/subpackages/manageiq-gemset
@@ -49,7 +49,7 @@ Requires: glusterfs-fuse
 %{product_summary} Gemset
 
 %files gemset
-%defattr(-,root,root,775)
+%defattr(-,root,root,-)
 %dir %{gemset_root}
 %{gemset_root}/bin
 %{gemset_root}/build_info

--- a/rpm_spec/subpackages/manageiq-system
+++ b/rpm_spec/subpackages/manageiq-system
@@ -18,7 +18,7 @@ Requires: openldap-clients
 %{product_summary} System
 
 %files system
-%defattr(-,root,root,775)
+%defattr(-,root,root,-)
 /.toprc
 /root/.ansible.cfg
 %{appliance_root}

--- a/rpm_spec/subpackages/manageiq-ui
+++ b/rpm_spec/subpackages/manageiq-ui
@@ -7,7 +7,9 @@ Requires: httpd
 %{product_summary} UI
 
 %files ui
-%defattr(-,root,root,775)
+%defattr(-,root,root,-)
+%attr(-,-,manageiq) %{app_root}/public/pictures
+%{app_root}/public/pictures
 %{app_root}/public/assets
 %{app_root}/public/packs
 %{app_root}/public/ui


### PR DESCRIPTION
Since services are running as `manageiq` or `root`, both users need to access the certs. We're mostly concerned with the `v2_key`. 

- Set group of created certificates (via `SGID` in `certs/` directory)so users create them properly
- Tweak the changes in https://github.com/ManageIQ/manageiq-rpm_build/pull/82 to set the privileges according to when the rpm build creates the directories via umask rather than force an override. This allows us to more easily create directories with different chmod like setting the `SGID` bit.
- have manageiq in charge of `log/apache`. Before 2 rpms were responsible.

This can be applied as an incremental change.

### Issues

#### sti loader

`sti_loader` is currently modified by our process even though we want it to.

```
rpm -V manageiq-core
S.5....T.    /var/www/miq/vmdb/tmp/cache/sti_loader.yml
```

ASIDE:
- we create these files in `appliance_console_cli`, so we are setting the correct permissions on these files over there as well. https://github.com/ManageIQ/manageiq-appliance_console/pull/163

---

- [ ] https://github.com/ManageIQ/manageiq-appliance/pull/318
- [ ] https://github.com/ManageIQ/manageiq/pull/21310
- [ ] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/264
- [ ] https://github.com/ManageIQ/manageiq-providers-autosde/pull/69
- [ ] https://github.com/ManageIQ/manageiq-providers-amazon/pull/713
- [ ] https://github.com/ManageIQ/manageiq-providers-azure/pull/461
- [ ] https://github.com/ManageIQ/manageiq-providers-azure_stack/pull/66
- [ ] https://github.com/ManageIQ/manageiq-providers-foreman/pull/90
- [ ] https://github.com/ManageIQ/manageiq-providers-google/pull/192
- [ ] https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/234
- [ ] https://github.com/ManageIQ/manageiq-providers-ibm_power_vc/pull/16
- [ ] https://github.com/ManageIQ/manageiq-providers-ibm_terraform/pull/67
- [ ] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/438
- [ ] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/188
- [ ] https://github.com/ManageIQ/manageiq-providers-lenovo/pull/334
- [ ] https://github.com/ManageIQ/manageiq-providers-nsxt/pull/43
- [ ] https://github.com/ManageIQ/manageiq-providers-nuage/pull/250
- [ ] https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/27
- [ ] https://github.com/ManageIQ/manageiq-providers-redfish/pull/143
- [ ] https://github.com/ManageIQ/manageiq-providers-openshift/pull/211
- [ ] https://github.com/ManageIQ/manageiq-providers-openstack/pull/720
- [ ] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/564
- [ ] https://github.com/ManageIQ/manageiq-providers-scvmm/pull/190
