### PR TITLE
add manageiq-initialize to rpm

### DIFF
--- a/rpm_spec/subpackages/manageiq-system
+++ b/rpm_spec/subpackages/manageiq-system
@@ -30,6 +30,7 @@ Requires: openldap-clients
 %{_bindir}/fix_auth
 %{_bindir}/generate_miq_server_cert.sh
 %{_bindir}/generate_rpm_manifest.sh
+%{_bindir}/manageiq*
 %{_bindir}/miq*
 %{_bindir}/normalize_userid_to_upn
 %{_bindir}/pg_inspector_server.sh


### PR DESCRIPTION
we are preferring manageiq over miq or evm.
Puts in a rule so we include these files into our rpm.
the bin files are mostly created by the COPY and LINK files in appliance repo

part of ManageIQ/manageiq-appliance-build#480