### PR TITLE
Put our ansible roles in standard location

### DIFF
--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -102,6 +102,12 @@ cd %{_builddir}
 #sample configuration files
 %{__mv} %{buildroot}%{app_root}/config/cable.yml.sample %{buildroot}%{app_root}/config/cable.yml
 
+# Move roles to playbook share
+mkdir -p %{buildroot}/usr/share/ansible/roles/
+for i in %{buildroot}%{app_root}/content/ansible_consolidated/roles/* ; do
+  %{__mv} $i %{buildroot}/usr/share/ansible/roles/
+done
+
 ## from appliance
 #symlink some executables
 %{__mkdir} -p %{buildroot}/%{_bindir}
@@ -121,11 +127,6 @@ pushd ./%{appliance_builddir}/LINK/etc
       done
     popd
   done
-popd
-
-%{__mkdir} -p %{buildroot}/root
-pushd ./%{appliance_builddir}/LINK/root
-  ln -s %{appliance_root}/LINK/root/.ansible.cfg %{buildroot}/root/.ansible.cfg
 popd
 
 pushd ./%{appliance_builddir}/LINK

--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -60,3 +60,4 @@ done
 %exclude %{app_root}/public/ui
 %exclude %{app_root}/public/upload
 %exclude %{app_root}/log/apache
+/usr/share/ansible/roles/

--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -40,7 +40,7 @@ done
 #  so root and manageiq users can read them.
 %{__chown} manageiq.manageiq %{app_root}/certs/v2_key %{app_root}/log/*.log
 %{__chown} manageiq.manageiq %{app_root}/tmp/pids/*.pid %{app_root}/config/*.yml
-%{__chown} -r manageiq.manageiq %{app_root}/data/
+%{__chown} -R manageiq.manageiq %{app_root}/data
 %{__chmod} o-rw %{app_root}/certs/v2_key
 %{__chmod} o-rw %{app_root}/config/*.yml %{app_root}/tmp/pids/*.pid
 %{__chmod} o-rw %{app_root}/log/*.log
@@ -52,7 +52,7 @@ done
 %attr(-,manageiq,manageiq) %{app_root}/config
 %attr(-,manageiq,manageiq) %{app_root}/log
 %attr(-,manageiq,manageiq) %{app_root}/tmp
-%attr(-,manageiq,manageiq) %{app_root}/data/git_repos
+%attr(-,manageiq,manageiq) %{app_root}/data
 %config(noreplace) %{app_root}/config/cable.yml
 %exclude %{app_root}/public/pictures
 %exclude %{app_root}/public/assets

--- a/rpm_spec/subpackages/manageiq-system
+++ b/rpm_spec/subpackages/manageiq-system
@@ -20,7 +20,6 @@ Requires: openldap-clients
 %files system
 %defattr(-,root,root,-)
 /.toprc
-/root/.ansible.cfg
 %{appliance_root}
 %{app_root}/log/apache
 %dir %{manifest_root}


### PR DESCRIPTION
related https://github.com/ManageIQ/manageiq-appliance/pull/324

Roles are found in `/etc/defalult/roles` and `/usr/share/ansible/roles`.
This information can be found in [ansible.cfg](https://github.com/ansible/ansible/blob/devel/examples/ansible.cfg#L67) and [reference/config](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-roles-path)

This PR puts our roles into the share directory to follow standard practices and not require that we have a custom configuration file updating the path.

The goal here is to remove the `root` centric configuration file. aka https://github.com/ManageIQ/manageiq/issues/20394

ASIDE: The [reuse docs](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#storing-and-finding-roles
) does list fewer directories, but I put in a PR to fix those docs. https://github.com/ansible/ansible/pull/75135

/cc @NickLaMuro @Fryguy 