### PR TITLE
Update libarchive to 3.3.3-1 to avoid rugged install failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN if [ ${ARCH} != "s390x" ] ; then dnf -y install http://mirror.centos.org/cen
       ruby-devel \
       rubygem-bundler \
       wget && \
+    dnf -y update libarchive && \
     dnf clean all
 
 RUN if [ ${ARCH} = "s390x" ] || [ ${ARCH} = "ppc64le" ] ; then dnf -y install python2 ; fi


### PR DESCRIPTION
cmake: symbol lookup error: cmake: undefined symbol: archive_write_add_filter_zstd
https://bugs.centos.org/view.php?id=18212