### PR TITLE
Resources owned by user manageiq for non-root appliances

### DIFF
--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -62,7 +62,6 @@ cd %{_builddir}
 ### from core
 %{__mkdir} -p %{buildroot}%{app_root}
 %{__cp} -r %{core_builddir}/* %{buildroot}%{app_root}
-%{__chmod} 2770 %{buildroot}%{app_root}/certs
 
 ### from appliance
 %{__mkdir} -p %{buildroot}%{appliance_root}
@@ -72,9 +71,9 @@ cd %{_builddir}
 %{__mkdir} -p %{buildroot}%{app_root}/tmp/{,sockets,pids}
 %{__mkdir} -p %{buildroot}%{app_root}/{certs,config}
 %{__mkdir} -p %{buildroot}%{app_root}/public/pictures
-%{__chmod} 2770 %{buildroot}%{app_root}/{log,config,certs}
-%{__chmod} 770 %{buildroot}%{app_root}/tmp/{,pids,sockets}
-%{__chmod} 775 %{buildroot}%{app_root}/public/pictures
+%{__chmod} 4750 %{buildroot}%{app_root}/{log,config,certs}
+%{__chmod} 700 %{buildroot}%{app_root}/tmp/{,pids,sockets}
+%{__chmod} 755 %{buildroot}%{app_root}/public/pictures
 
 ### from gemset
 %{__mkdir} -p %{buildroot}%{gemset_root}

--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -20,7 +20,7 @@ Requires: socat
 
 %pre core
 # ensure this user exists (build and upgrade)
-/usr/bin/id manageiq > /dev/null 2>&1 || /usr/sbin/useradd --system manageiq && /usr/sbin/usermod -aG manageiq root
+/usr/bin/id manageiq > /dev/null 2>&1 || /usr/sbin/useradd --system manageiq
 
 %posttrans core
 # 'bin' needs to be copied, not symlinked
@@ -39,23 +39,23 @@ done
 # These files are not owned by the rpm.
 #  For upgrades, ensure they have the correct group privs
 #  so root and manageiq users can read them.
-%{__chgrp} manageiq %{app_root}/certs/v2_key %{app_root}/log/*.log
-%{__chgrp} manageiq %{app_root}/tmp/pids/*.pid %{app_root}/config/*.yml
-%{__chmod} g+r,o-rw %{app_root}/certs/v2_key
-%{__chmod} g+r,o-rw %{app_root}/config/*.yml %{app_root}/tmp/pids/*.pid
-%{__chmod} g+rw %{app_root}/log/*.log
+%{__chown} manageiq.manageiq %{app_root}/certs/v2_key %{app_root}/log/*.log
+%{__chown} manageiq.manageiq %{app_root}/tmp/pids/*.pid %{app_root}/config/*.yml
+%{__chmod} o-rw %{app_root}/certs/v2_key
+%{__chmod} o-rw %{app_root}/config/*.yml %{app_root}/tmp/pids/*.pid
+%{__chmod} o-rw %{app_root}/log/*.log
 
 %files core
 %defattr(-,root,root,-)
 %{app_root}
 %config(noreplace) %{app_root}/certs
-%attr(-,-,manageiq) %{app_root}/certs
-%attr(-,-,manageiq) %{app_root}/config
-%attr(-,-,manageiq) %{app_root}/log
-%attr(-,-,manageiq) %{app_root}/tmp
-# this is until we fix the code that auto writes this
-# give kbrock a hard time if it is 2022 and this is still in here
-%attr(0664,-,-) %{app_root}/tmp/cache/sti_loader.yml
+%attr(-,manageiq,manageiq) %{app_root}/certs
+%attr(-,manageiq,manageiq) %{app_root}/config
+%attr(-,manageiq,manageiq) %{app_root}/log
+%attr(-,manageiq,manageiq) %{app_root}/tmp
+## this is until we fix the code that auto writes this
+## give kbrock a hard time if it is 2022 and this is still in here
+%attr(0644,manageiq,manageiq) %{app_root}/tmp/cache/sti_loader.yml
 %exclude %{app_root}/public/pictures
 %exclude %{app_root}/public/assets
 %exclude %{app_root}/public/packs

--- a/rpm_spec/subpackages/manageiq-ui
+++ b/rpm_spec/subpackages/manageiq-ui
@@ -8,7 +8,7 @@ Requires: httpd
 
 %files ui
 %defattr(-,root,root,-)
-%attr(-,-,manageiq) %{app_root}/public/pictures
+%attr(-,manageiq,manageiq) %{app_root}/public/pictures
 %{app_root}/public/pictures
 %{app_root}/public/assets
 %{app_root}/public/packs


### PR DESCRIPTION
dependency:

- [x] https://github.com/ManageIQ/manageiq-rpm_build/pull/157
 
In the previous PR, resources were transitioned to the `manageiq` group.
This changes over to the `manageiq` user. This makes fixes issues with the logs, umask, and chmod items.
It also simplifies things since users are more familiar working with users than groups.