### PR TITLE
Fix production over-writing sti_loader.yml

### DIFF
--- a/lib/manageiq/rpm_build/generate_core.rb
+++ b/lib/manageiq/rpm_build/generate_core.rb
@@ -43,7 +43,7 @@ module ManageIQ
 
       def precompile_sti_loader
         Dir.chdir(miq_dir) do
-          shell_cmd("bundle exec rake evm:compile_sti_loader")
+          shell_cmd("BUNDLER_GROUPS=manageiq_default,ui_dependencies,graphql_api bundle exec rake evm:compile_sti_loader")
 
           fixup_sti_loader!
         end

--- a/lib/manageiq/rpm_build/generate_core.rb
+++ b/lib/manageiq/rpm_build/generate_core.rb
@@ -103,6 +103,10 @@ module ManageIQ
       def fixup_sti_loader!
         sti_loader_yml_path = miq_dir.join("tmp/cache/sti_loader.yml")
 
+        core_prefix       = OPTIONS.product_name
+        gemset_prefix     = "#{OPTIONS.product_name}-gemset"
+        target_gemset_dir = File.join("", "opt", OPTIONS.rpm.org_name)
+
         sti_loader = YAML.load_file(sti_loader_yml_path)
 
         # Replace paths from the rpm build with the paths that will exist at runtime
@@ -110,20 +114,20 @@ module ManageIQ
           if !path.start_with?(BUILD_DIR.to_s)
             path
           else
-            rel_path = Pathname.new(path).relative_path_from(BUILD_DIR)
-            prefix, target_path = rel_path.to_s.split("/", 2)
+            relative_path       = Pathname.new(path).relative_path_from(BUILD_DIR)
+            prefix, target_path = relative_path.to_s.split("/", 2)
 
-            prefix =
+            target_dir =
               case prefix
-              when OPTIONS.product_name
+              when core_prefix
                 "/var/www/miq/vmdb"
-              when /^#{OPTIONS.product_name}-gemset/
-                File.join("", "opt", OPTIONS.rpm.org_name, "#{OPTIONS.product_name}-gemset")
+              when /^#{gemset_prefix}/
+                File.join(target_gemset_dir, gemset_prefix)
               else
                 raise "Invalid file path in STI cache: #{path}"
               end
 
-            File.join(prefix, target_path)
+            File.join(target_dir, target_path)
           end
         end
 

--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -61,11 +61,11 @@ cd %{_builddir}
 
 ### from core
 %{__mkdir} -p %{buildroot}%{app_root}
-%{__cp} -r %{core_builddir}/* %{buildroot}%{app_root}
+%{__cp} -a %{core_builddir}/* %{buildroot}%{app_root}
 
 ### from appliance
 %{__mkdir} -p %{buildroot}%{appliance_root}
-%{__cp} -r %{appliance_builddir}/* %{buildroot}%{appliance_root}
+%{__cp} -a %{appliance_builddir}/* %{buildroot}%{appliance_root}
 %{__mkdir} -p %{buildroot}/etc/httpd/conf.d
 %{__mkdir} -p %{buildroot}%{app_root}/log/apache
 %{__mkdir} -p %{buildroot}%{app_root}/tmp/{,sockets,pids}
@@ -77,24 +77,24 @@ cd %{_builddir}
 
 ### from gemset
 %{__mkdir} -p %{buildroot}%{gemset_root}
-%{__cp} -r %{gemset_builddir}/bin %{buildroot}%{gemset_root}
-%{__cp} -r %{gemset_builddir}/build_info %{buildroot}%{gemset_root}
-%{__cp} -r %{gemset_builddir}/bundler %{buildroot}%{gemset_root}
-%{__cp} -r %{gemset_builddir}/cache %{buildroot}%{gemset_root}
-%{__cp} -r %{gemset_builddir}/doc %{buildroot}%{gemset_root}
-%{__cp} -r %{gemset_builddir}/extensions %{buildroot}%{gemset_root}
-%{__cp} -r %{gemset_builddir}/gems %{buildroot}%{gemset_root}
-%{__cp} -r %{gemset_builddir}/specifications %{buildroot}%{gemset_root}
-%{__cp} -r %{gemset_builddir}/vmdb %{buildroot}%{gemset_root}
+%{__cp} -a %{gemset_builddir}/bin %{buildroot}%{gemset_root}
+%{__cp} -a %{gemset_builddir}/build_info %{buildroot}%{gemset_root}
+%{__cp} -a %{gemset_builddir}/bundler %{buildroot}%{gemset_root}
+%{__cp} -a %{gemset_builddir}/cache %{buildroot}%{gemset_root}
+%{__cp} -a %{gemset_builddir}/doc %{buildroot}%{gemset_root}
+%{__cp} -a %{gemset_builddir}/extensions %{buildroot}%{gemset_root}
+%{__cp} -a %{gemset_builddir}/gems %{buildroot}%{gemset_root}
+%{__cp} -a %{gemset_builddir}/specifications %{buildroot}%{gemset_root}
+%{__cp} -a %{gemset_builddir}/vmdb %{buildroot}%{gemset_root}
 
 # Copy systemd unit files
 %{__mkdir} -p %{buildroot}%{_prefix}/lib/systemd/system
-%{__cp} %{core_builddir}/systemd/* %{buildroot}/%{_prefix}/lib/systemd/system
-%{__cp} %{gemset_builddir}/bundler/gems/*/systemd/* %{buildroot}/%{_prefix}/lib/systemd/system
+%{__cp} -a %{core_builddir}/systemd/* %{buildroot}/%{_prefix}/lib/systemd/system
+%{__cp} -a %{gemset_builddir}/bundler/gems/*/systemd/* %{buildroot}/%{_prefix}/lib/systemd/system
 
 ### from manifest
 %{__mkdir} -p %{buildroot}%{manifest_root}
-%{__cp} -r %{manifest_builddir}/* %{buildroot}%{manifest_root}
+%{__cp} -a %{manifest_builddir}/* %{buildroot}%{manifest_root}
 
 # Move webpack manifests
 %{__mv} %{buildroot}%{app_root}/public/packs/webpack_modules_manifest.json %{buildroot}%{manifest_root}
@@ -133,8 +133,7 @@ pushd ./%{appliance_builddir}/LINK
 popd
 
 #copy all files/directories below COPY
-%{__cp} -r ./%{appliance_builddir}/COPY/* %{buildroot}/
+%{__cp} -a ./%{appliance_builddir}/COPY/* %{buildroot}/
 
 %clean
 rm -rf $RPM_BUILD_ROOT
-

--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -25,7 +25,7 @@ Requires: socat
 %posttrans core
 # 'bin' needs to be copied, not symlinked
 [[ -e /var/www/miq/vmdb/bin ]] && rm -rf /var/www/miq/vmdb/bin
-cp -r %{gemset_root}/vmdb/bin /var/www/miq/vmdb/bin
+cp -a %{gemset_root}/vmdb/bin /var/www/miq/vmdb/bin
 
 files=".bundle Gemfile.lock"
 for file in ${files}


### PR DESCRIPTION
When precompiling the sti_loader the paths to the source files are relative to the build machine so /root/BUILD rather than relative to the target files on the appliance like /var/www/miq/vmdb.

The file created by the rpm_build looks like:
```yaml
---
"@version": 2
"/root/BUILD/manageiq/app/models/account.rb":
  :mtime: 2021-07-01 00:01:15.114170979 +00:00
  :parsed:
  - - - ''
    - - ''
    - Account
    - ApplicationRecord
```

When the application starts up the first time it doesn't find any of these files and effectively re-builds the sti_loader on first boot, then the first time it is shut down it writes out all the new paths in addition to the old ones.

```yaml
"/var/www/miq/vmdb/app/models/account.rb":
  :mtime: 2021-06-30 20:31:34.000000000 -04:00
  :parsed:
  - - - ''
    - - ''
    - Account
    - ApplicationRecord
```

And an example from the gemset:
```yaml
"/root/BUILD/manageiq-gemset-13.0.0/bundler/gems/manageiq-api-7e47a11dabfb/app/controllers/api/actions_controller.rb":
  :mtime: 2021-07-02 00:01:52.199731453 +00:00
  :parsed:
  - - - Api
      - ''
    - - Api
    - ActionsController
    - BaseController
```

And fixed up:
```yaml
"/opt/manageiq/manageiq-gemset/bundler/gems/manageiq-api-7e47a11dabfb/app/controllers/api/actions_controller.rb":
  :mtime: 2021-07-02 00:01:52.000000000 +00:00
  :parsed:
  - - - Api
      - ''
    - - Api
    - ActionsController
    - BaseController
```

Remaining issues:
- [x] RPM installed files don't have milliseconds on their modified times (tar limitation) so the timestamp value in the yml doesn't match the mtime of the file
- [x] mtime of the files installed by RPM don't match the content of the sti_loader.yml (off by 29mins)
- [ ] Two graphql classes are missing from the pre-compiled sti_loader and get written out on appliance startup