### PR TITLE
Fix downstream RPM build

### DIFF
--- a/lib/manageiq/rpm_build/generate_core.rb
+++ b/lib/manageiq/rpm_build/generate_core.rb
@@ -102,12 +102,7 @@ module ManageIQ
 
       def fixup_sti_loader!
         sti_loader_yml_path = miq_dir.join("tmp/cache/sti_loader.yml")
-
-        core_prefix       = OPTIONS.product_name
-        gemset_prefix     = "#{OPTIONS.product_name}-gemset"
-        target_gemset_dir = File.join("", "opt", OPTIONS.rpm.org_name)
-
-        sti_loader = YAML.load_file(sti_loader_yml_path)
+        sti_loader          = YAML.load_file(sti_loader_yml_path)
 
         # Replace paths from the rpm build with the paths that will exist at runtime
         sti_loader.transform_keys! do |path|
@@ -119,10 +114,10 @@ module ManageIQ
 
             target_dir =
               case prefix
-              when core_prefix
+              when "manageiq"
                 "/var/www/miq/vmdb"
-              when /^#{gemset_prefix}/
-                File.join(target_gemset_dir, gemset_prefix)
+              when /^manageiq-gemset/
+                File.join("", "opt", OPTIONS.rpm.org_name, "#{OPTIONS.product_name}-gemset")
               else
                 raise "Invalid file path in STI cache: #{path}"
               end


### PR DESCRIPTION
The paths on the build machine are not different depending on the `OPTIONS.product_name`

Introduced by https://github.com/ManageIQ/manageiq-rpm_build/pull/162

```
/build_scripts/lib/manageiq/rpm_build/generate_core.rb:127:in `block in fixup_sti_loader!': Invalid file path in STI cache: /root/BUILD/manageiq/app/models/storage_profile.rb (RuntimeError)
	from /build_scripts/lib/manageiq/rpm_build/generate_core.rb:113:in `transform_keys!'
	from /build_scripts/lib/manageiq/rpm_build/generate_core.rb:113:in `fixup_sti_loader!'
	from /build_scripts/lib/manageiq/rpm_build/generate_core.rb:48:in `block in precompile_sti_loader'
	from /build_scripts/lib/manageiq/rpm_build/generate_core.rb:45:in `chdir'
	from /build_scripts/lib/manageiq/rpm_build/generate_core.rb:45:in `precompile_sti_loader'
	from /build_scripts/lib/manageiq/rpm_build/generate_core.rb:82:in `populate'
	from bin/build.rb:29:in `<main>'
```