### PR TITLE
Fix the gemset prefix for downstream builds

### DIFF
--- a/lib/manageiq/rpm_build/generate_core.rb
+++ b/lib/manageiq/rpm_build/generate_core.rb
@@ -116,7 +116,7 @@ module ManageIQ
               case prefix
               when "manageiq"
                 "/var/www/miq/vmdb"
-              when /^manageiq-gemset/
+              when /^#{OPTIONS.product_name}-gemset/
                 File.join("", "opt", OPTIONS.rpm.org_name, "#{OPTIONS.product_name}-gemset")
               else
                 raise "Invalid file path in STI cache: #{path}"


### PR DESCRIPTION
The path for the core repo is always `/root/BUILD/manageiq` but the gemset path uses the `OPTIONS.product_name` so it is different for upstream/downstream builds.

`GEM_HOME` is setup here: https://github.com/ManageIQ/manageiq-rpm_build/blob/master/lib/manageiq/rpm_build.rb#L33

```
/build_scripts/lib/manageiq/rpm_build/generate_core.rb:122:in `block in fixup_sti_loader!': Invalid file path in STI cache: /root/BUILD/infrastructure-management-gemset-13.0.0/bundler/gems/bluecf-api-7e47a11dabfb/app/controllers/api/container_templates_controller.rb (RuntimeError)
```