### PR TITLE
Remove . from RPM release number

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,21 @@ docker cp ${CONTAINER}:/root/BUILD/rpms/x86_64/ ./rpms/
 docker rm ${CONTAINER}
 ```
 
+## Versioning
+
+Branch `morphy` == v13
+
+| Version               | Purpose     | Repo    |
+|-----------------------|-------------|---------|
+| 13.0.0-20210708000051 | nightly     | nightly |
+| 13.0.1-beta1          | pre-release | release |
+| 13.0.1-20210708000051 | nightly     | nightly |
+| 13.0.2-rc1            | pre-release | release |
+| 13.1.0-0              | release     | release |
+| 13.1.0-20210708000051 | nightly     | nightly |
+| 13.2.0-0              | release     | release |
+| 13.2.0-20210708000051 | nightly     | nightly |
+
 ## License
 
 This code is available as open source under the terms of the [Apache License 2.0](LICENSE).

--- a/config/options.yml
+++ b/config/options.yml
@@ -15,7 +15,7 @@ version:
 release:
 rpm:
   version:         13.0.0
-  release:         0.1
+  release:         0
   repo_name:
   org_name:        manageiq
   product_summary: ManageIQ Management Engine

--- a/lib/manageiq/rpm_build/build_copr.rb
+++ b/lib/manageiq/rpm_build/build_copr.rb
@@ -65,10 +65,10 @@ module ManageIQ
 
       def spec_release
         if release_name.empty?
-          "#{rpm_release}.#{BUILD_DATE}"
+          BUILD_DATE
         else
           pre_build = release_name.split("-")[2]
-          pre_build ? "#{rpm_release}.#{pre_build}" : "#{rpm_release}"
+          pre_build ? "#{pre_build}" : "#{rpm_release}"
         end
       end
     end


### PR DESCRIPTION
- Change 0.1 to 0 in the config
- Switch from 0.1.timestamp to timestamp only in the release
- Add versioning information to the README (with some changes from the previous versioning)

We've been seeing issues with the appliance build where all of the ManageIQ RPMs are installed, but nightlies don't have the latest version of the RPM. After some reading, my best guess is that we're incorrectly using the release since we should follow `name-epoch:version-release.architecture` where `epoch:` is optional.

Nightly:
  Before: manageiq-core-13.0.0-0.1.20210708000051.el8.x86_64
  After:  manageiq-core-13.0.0-20210708000051.el8.x86_64
Pre-release:
  Before: manageiq-core-13.0.0-0.1.beta1.el8.x86_64
  After:  manageiq-core-13.0.1-beta1.el8.x86_64
Release:
  Before: manageiq-core-13.0.0-0.1.el8.x86_64
  After:  manageiq-core-13.1.0-1.el8.x86_64

Additional reading:
https://blog.jasonantman.com/2014/07/how-yum-and-rpm-compare-versions/