### PR TITLE
Followup from #166

### DIFF
--- a/config/options.yml
+++ b/config/options.yml
@@ -56,4 +56,4 @@ rpm_repository:
       :targets:
         - el8
       :rpms:
-        :manageiq-nightly: !ruby/regexp /.+-13\.\d\.\d-\d\.\d\.\d+\.el.+/
+        :manageiq-nightly: !ruby/regexp /.+-13\.\d\.\d-(\d\.\d\.)?\d+\.el.+/


### PR DESCRIPTION
release -x.y.timestamp now x.y. is no longer used, make it optional for now
Based on #166