### PR TITLE
Return descendent loader cache to regular privs

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -53,9 +53,6 @@ done
 %attr(-,manageiq,manageiq) %{app_root}/config
 %attr(-,manageiq,manageiq) %{app_root}/log
 %attr(-,manageiq,manageiq) %{app_root}/tmp
-## this is until we fix the code that auto writes this
-## give kbrock a hard time if it is 2022 and this is still in here
-%attr(0644,manageiq,manageiq) %{app_root}/tmp/cache/sti_loader.yml
 %exclude %{app_root}/public/pictures
 %exclude %{app_root}/public/assets
 %exclude %{app_root}/public/packs


### PR DESCRIPTION
related to https://github.com/ManageIQ/manageiq/issues/20394

we were trying to overwrite the descenent loader cache
This was fixed in d4ecc500c8c ( https://github.com/ManageIQ/manageiq/pull/21321 )

now we no longer need the special/explicit privileges