### PR TITLE
Create app_root/public/upload directory

### DIFF
--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -71,6 +71,7 @@ cd %{_builddir}
 %{__mkdir} -p %{buildroot}%{app_root}/tmp/{,sockets,pids}
 %{__mkdir} -p %{buildroot}%{app_root}/{certs,config}
 %{__mkdir} -p %{buildroot}%{app_root}/public/pictures
+%{__mkdir} -p %{buildroot}%{app_root}/public/upload
 %{__chmod} 4750 %{buildroot}%{app_root}/{log,config,certs}
 %{__chmod} 700 %{buildroot}%{app_root}/tmp/{,pids,sockets}
 %{__chmod} 755 %{buildroot}%{app_root}/public/pictures

--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -54,6 +54,7 @@ done
 %attr(-,manageiq,manageiq) %{app_root}/log
 %attr(-,manageiq,manageiq) %{app_root}/tmp
 %exclude %{app_root}/public/pictures
+%exclude %{app_root}/public/upload
 %exclude %{app_root}/public/assets
 %exclude %{app_root}/public/packs
 %exclude %{app_root}/public/ui

--- a/rpm_spec/subpackages/manageiq-ui
+++ b/rpm_spec/subpackages/manageiq-ui
@@ -10,7 +10,9 @@ Requires: mod_ssl
 %files ui
 %defattr(-,root,root,-)
 %attr(-,manageiq,manageiq) %{app_root}/public/pictures
+%attr(-,manageiq,manageiq) %{app_root}/public/upload
 %{app_root}/public/pictures
+%{app_root}/public/upload
 %{app_root}/public/assets
 %{app_root}/public/packs
 %{app_root}/public/ui


### PR DESCRIPTION
The `/var/www/miq/vmdb/public/upload` directory was being created dynamically by the UI worker.  The `/var/www/miq/vmdb/public` dir is owned by root and so the worker was throwing an exception trying to create a directory under it as the `manageiq` user which was preventing any application settings from being saved.

Fixes https://github.com/ManageIQ/manageiq/issues/21359