### PR TITLE
Use standard rpm semantics for cable.yml sample file

### DIFF
--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -99,6 +99,9 @@ cd %{_builddir}
 %{__mv} %{buildroot}%{app_root}/public/ui/service/webpack_modules_manifest.json %{buildroot}%{manifest_root}/webpack_modules_manifest_service_ui.json
 %{__mv} %{buildroot}%{app_root}/public/ui/service/webpack_packages_manifest.json %{buildroot}%{manifest_root}/webpack_packages_manifest_service_ui.json
 
+#sample configuration files
+%{__mv} %{buildroot}%{app_root}/config/cable.yml.sample %{buildroot}%{app_root}/config/cable.yml
+
 ## from appliance
 #symlink some executables
 %{__mkdir} -p %{buildroot}/%{_bindir}

--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -35,7 +35,6 @@ do
 done
 
 %post core
-%{__cp} -f %{app_root}/config/cable.yml.sample %{app_root}/config/cable.yml
 # These files are not owned by the rpm.
 #  For upgrades, ensure they have the correct group privs
 #  so root and manageiq users can read them.
@@ -49,12 +48,12 @@ done
 %files core
 %defattr(-,root,root,-)
 %{app_root}
-%config(noreplace) %{app_root}/certs
 %attr(-,manageiq,manageiq) %{app_root}/certs
 %attr(-,manageiq,manageiq) %{app_root}/config
 %attr(-,manageiq,manageiq) %{app_root}/log
 %attr(-,manageiq,manageiq) %{app_root}/tmp
 %attr(-,manageiq,manageiq) %{app_root}/data/git_repos
+%config(noreplace) %{app_root}/config/cable.yml
 %exclude %{app_root}/public/pictures
 %exclude %{app_root}/public/assets
 %exclude %{app_root}/public/packs


### PR DESCRIPTION
We currently just overwrite the `cable.yml` on every install.
This is probably fine since it is not really configurable by the end user.

But rpms typically mark a changeable configuration file as `config(noreplace)`
If the file does change, rpm creates an `.rpmsave` file to help the admin decide how to handle this conflict.

Also, this file will now be in the rpm database, so the user can tell if the user modified anything.

### Before

- new `vmdb/config/cable.yml` every time

### After

- updates to `vmdb/config/cable.yml`
- if the user has modified that file, it is unchanged but a `vmdb/config.cable.yml.rpmnew` is created