### PR TITLE
Reduce disk space of locale files

### DIFF
--- a/lib/manageiq/rpm_build/generate_core.rb
+++ b/lib/manageiq/rpm_build/generate_core.rb
@@ -82,7 +82,7 @@ module ManageIQ
         precompile_sti_loader
         build_service_ui
         seed_ansible_runner
-        cleanse_locale_files
+        compile_locale_files
 
         if OPTIONS.npm_registry
           Dir.chdir(miq_dir) do
@@ -150,10 +150,14 @@ module ManageIQ
         end
       end
 
-      def cleanse_locale_files
-        # remove all comment lines from locale files
-        # the comment lines beginning with #, are special
-        shell_cmd("sed -i'' -e '/^#[^,]/d' #{miq_dir.join('locale/*/*.po')}")
+      def compile_locale_files
+        miq_dir.glob("locale/*/*.po").each do |po|
+          mo = po.dirname.join("LC_MESSAGES", "#{File.basename(po, '.po')}.mo")
+          mo.dirname.mkpath
+          shell_cmd("msgfmt #{po} -o #{mo}")
+        end
+        shell_cmd("rm #{miq_dir.join('locale/*/*.po')}")
+        shell_cmd("rm #{miq_dir.join('locale/*.pot')}")
       end
     end
   end

--- a/lib/manageiq/rpm_build/generate_core.rb
+++ b/lib/manageiq/rpm_build/generate_core.rb
@@ -82,6 +82,7 @@ module ManageIQ
         precompile_sti_loader
         build_service_ui
         seed_ansible_runner
+        cleanse_locale_files
 
         if OPTIONS.npm_registry
           Dir.chdir(miq_dir) do
@@ -147,6 +148,12 @@ module ManageIQ
             FileUtils.ln_s(path.join(subdir), target_path.join(subdir))
           end
         end
+      end
+
+      def cleanse_locale_files
+        # remove all comment lines from locale files
+        # the comment lines beginning with #, are special
+        shell_cmd("sed -i'' -e '/^#[^,]/d' #{miq_dir.join('locale/*/*.po')}")
       end
     end
   end


### PR DESCRIPTION
requires:

- [x] https://github.com/ManageIQ/manageiq/pull/21406

~~there are comments at the top of the locale files~~
~~removing these comments reduces the disk space by half (15meg)~~

Using `.mo` files instead of `.po` files to reduce disk space.

testing w/ upgrading rpms on an existing appliance.

### Before

```
[root@localhost vmdb]# wc locale/*/*.po
   82152  246744 3068312 locale/de/manageiq.po
   83011  201527 2496587 locale/en/manageiq.po
   82152  274848 3127414 locale/es/manageiq.po
   82152  276191 3131189 locale/fr/manageiq.po
   82152  263833 3057572 locale/it/manageiq.po
   81604  216590 3167343 locale/ja/manageiq.po
   81604  258917 3090377 locale/ko/manageiq.po
   82152  272322 3142088 locale/pt_BR/manageiq.po
   81604  215609 2902947 locale/zh_CN/manageiq.po
   81604  217728 2917629 locale/zh_TW/manageiq.po
  820187 2444309 30,101,458 total
[root@localhost vmdb]# du -sh locale
 31M	locale
```

### After

```
[root@localhost vmdb]# wc locale/*/*.mo
    3581   113159  1493525 locale/de/manageiq.mo
      11       32      462 locale/en/manageiq.mo
    3480   140302  1552600 locale/es/manageiq.mo
    3491   141413  1556361 locale/fr/manageiq.mo
    3550   129736  1482781 locale/it/manageiq.mo
    3422    79023  1599177 locale/ja/manageiq.mo
    3472   111029  1522165 locale/ko/manageiq.mo
    3406   137673  1567245 locale/pt_BR/manageiq.mo
    3585    76814  1335809 locale/zh_CN/manageiq.mo
    3558    78617  1349450 locale/zh_TW/manageiq.mo
   31556  1007798 13,459,575 total
[root@localhost vmdb]# du -sh locale
16M	locale
```

## old

**No longer valid***, but keeping around for posterity sake.

### After

```
[root@localhost vmdb]# wc locale/*/*.po
   52907  170794 1454711 locale/de/manageiq.po
   53766  125577  882986 locale/en/manageiq.po
   52907  198898 1513813 locale/es/manageiq.po
   52907  200241 1517588 locale/fr/manageiq.po
   52907  187883 1443971 locale/it/manageiq.po
   52359  140640 1553742 locale/ja/manageiq.po
   52359  182967 1476776 locale/ko/manageiq.po
   52907  196372 1528487 locale/pt_BR/manageiq.po
   52359  139659 1289346 locale/zh_CN/manageiq.po
   52359  141778 1304028 locale/zh_TW/manageiq.po
  527737 1684809 13,965,448 total
[root@localhost vmdb]# du -sh locale
16M	locale
```