### PR TITLE
Replace rake update_{stop,start} with systemctl try-restart evmserverd

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -55,29 +55,8 @@ Requires: yum-utils
 %description appliance
 %{product_summary} Appliance
 
-%pretrans appliance -p <lua>
-if posix.access('/bin/evmserver.sh', 'x') then
-  local pid = posix.fork ()
-  if ( pid == -1 ) then
-    print ("The fork failed.")
-  elseif ( pid == 0 ) then
-    posix.exec('/bin/evmserver.sh', 'update_stop')
-  else
-    posix.wait(pid)
-  end
-end
-
-%posttrans appliance -p <lua>
-if posix.access('/bin/evmserver.sh', 'x') then
-  local pid = posix.fork ()
-  if ( pid == -1 ) then
-    print ("The fork failed.")
-  elseif ( pid == 0 ) then
-    posix.exec('/bin/evmserver.sh', 'update_start')
-  else
-    posix.wait(pid)
-  end
-end
+%posttrans appliance
+%{_bindir}/systemctl try-restart evmserverd.service
 
 %post appliance
 #motd is owned by system


### PR DESCRIPTION
Instead of stopping evmserverd, writing no_db to the pid file, then starting it again after simply issue try-restart after rpms finish install

Part of: https://github.com/ManageIQ/manageiq-appliance/pull/327