### PR TITLE
rpm install: Don't warn for missing files

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -38,12 +38,12 @@ done
 # These files are not owned by the rpm.
 #  For upgrades, ensure they have the correct group privs
 #  so root and manageiq users can read them.
-%{__chown} manageiq.manageiq %{app_root}/certs/v2_key %{app_root}/log/*.log
-%{__chown} manageiq.manageiq %{app_root}/tmp/pids/*.pid %{app_root}/config/*.yml
+%{__chown} -f manageiq.manageiq %{app_root}/certs/v2_key %{app_root}/log/*.log
+%{__chown} -f manageiq.manageiq %{app_root}/tmp/pids/*.pid %{app_root}/config/*.yml
 %{__chown} -R manageiq.manageiq %{app_root}/data
-%{__chmod} o-rw %{app_root}/certs/v2_key
-%{__chmod} o-rw %{app_root}/config/*.yml %{app_root}/tmp/pids/*.pid
-%{__chmod} o-rw %{app_root}/log/*.log
+%{__chmod} -f o-rw %{app_root}/certs/v2_key
+%{__chmod} -f o-rw %{app_root}/config/*.yml %{app_root}/tmp/pids/*.pid
+%{__chmod} -f o-rw %{app_root}/log/*.log
 
 %files core
 %defattr(-,root,root,-)

--- a/rpm_spec/subpackages/manageiq-ui
+++ b/rpm_spec/subpackages/manageiq-ui
@@ -11,7 +11,7 @@ Requires: mod_ssl
 # These files are not owned by the rpm.
 #  For upgrades, ensure they have the correct group privs
 #  so root and manageiq users can read them.
-%{__chown} manageiq.manageiq %{app_root}/public/{pictures,upload}/*
+%{__chown} -f manageiq.manageiq %{app_root}/public/{pictures,upload}/*
 
 %files ui
 %defattr(-,root,root,-)


### PR DESCRIPTION
there are a number of files that are now going to be owned
by non-root users. The rpm runs chmod/chown for the user but
we are getting warnings if the files do not exist yet.

This PR hides those errors

Fixes https://github.com/ManageIQ/manageiq-rpm_build/issues/186