### PR TITLE
[MORPHY] Remove . from RPM release number

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,21 @@ docker cp ${CONTAINER}:/root/BUILD/rpms/x86_64/ ./rpms/
 docker rm ${CONTAINER}
 ```
 
+## Versioning
+
+Branch `morphy` == v13
+
+| Version               | Purpose     | Repo    |
+|-----------------------|-------------|---------|
+| 13.0.0-20210708000051 | nightly     | nightly |
+| 13.0.1-beta1          | pre-release | release |
+| 13.0.1-20210708000051 | nightly     | nightly |
+| 13.0.2-rc1            | pre-release | release |
+| 13.1.0-0              | release     | release |
+| 13.1.0-20210708000051 | nightly     | nightly |
+| 13.2.0-0              | release     | release |
+| 13.2.0-20210708000051 | nightly     | nightly |
+
 ## License
 
 This code is available as open source under the terms of the [Apache License 2.0](LICENSE).

--- a/lib/manageiq/rpm_build/build_copr.rb
+++ b/lib/manageiq/rpm_build/build_copr.rb
@@ -65,10 +65,10 @@ module ManageIQ
 
       def spec_release
         if release_name.empty?
-          "#{rpm_release}.#{BUILD_DATE}"
+          BUILD_DATE
         else
           pre_build = release_name.split("-")[2]
-          pre_build ? "#{rpm_release}.#{pre_build}" : "#{rpm_release}"
+          pre_build ? "#{pre_build}" : "#{rpm_release}"
         end
       end
     end


### PR DESCRIPTION
Morphy backport of #166 

Remove . from RPM release number

(cherry picked from commit 433a2df9d44a04098e2d7372a3dc55e658040ba9)