### PR TITLE
Update lockfiles

### DIFF
--- a/bin/generate_core_lockfile.rb
+++ b/bin/generate_core_lockfile.rb
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+
+require 'bundler'
+ENV["BUNDLE_GEMFILE"] = "/tmp/lock_generator/Gemfile"
+
+# Set up working directory
+require 'fileutils'
+FileUtils.mkdir_p("/tmp/lock_generator/bundler.d")
+FileUtils.cp("/mnt/Gemfile", "/tmp/lock_generator/")
+FileUtils.cp("/mnt/Gemfile.release.rb", "/tmp/lock_generator/bundler.d/") if File.file?("/mnt/Gemfile.release.rb")
+branch = Bundler.load.dependencies.detect { |i| i.name == "manageiq-api" }.branch
+puts "Bundling for branch: #{branch}..."
+exit $?.exitstatus unless system("git clone https://github.com/ManageIQ/manageiq-appliance.git -b #{branch} /tmp/manageiq-appliance")
+FileUtils.cp("/tmp/manageiq-appliance/manageiq-appliance-dependencies.rb", "/tmp/lock_generator/bundler.d/")
+
+# Generate Gemfile.lock
+exit $?.exitstatus unless system({"APPLIANCE" => "true", "BUNDLE_GEMFILE" => ENV["BUNDLE_GEMFILE"]}, "bundle update --jobs=8")
+
+# Generate the lockfiles
+p = Bundler::LockfileParser.new(Bundler.read_file("#{ENV["BUNDLE_GEMFILE"]}.lock"))
+lock_contents = p.specs.each_with_object("") do |gem, lock|
+  next if gem.source.kind_of?(Bundler::Source::Git)
+  lock << "ensure_gem \"#{gem.name}\", \"=#{gem.version}\"\n"
+end
+
+# Copy results back to the mounted manageiq repo
+File.write("/mnt/bundler.d/Gemfile.release.rb", lock_contents)
+FileUtils.cp("#{ENV["BUNDLE_GEMFILE"]}.lock", "/mnt/Gemfile.lock.release")
+
+puts "Complete!"

--- a/bin/generate_core_lockfile.rb
+++ b/bin/generate_core_lockfile.rb
@@ -14,7 +14,7 @@ exit $?.exitstatus unless system("git clone https://github.com/ManageIQ/manageiq
 FileUtils.cp("/tmp/manageiq-appliance/manageiq-appliance-dependencies.rb", "/tmp/lock_generator/bundler.d/")
 
 # Generate Gemfile.lock
-exit $?.exitstatus unless system({"APPLIANCE" => "true", "BUNDLE_GEMFILE" => ENV["BUNDLE_GEMFILE"]}, "bundle update --jobs=8")
+exit $?.exitstatus unless system({"APPLIANCE" => "true", "BUNDLE_GEMFILE" => ENV["BUNDLE_GEMFILE"]}, "bundle update --jobs=8 --retry=3")
 
 # Generate the lockfiles
 p = Bundler::LockfileParser.new(Bundler.read_file("#{ENV["BUNDLE_GEMFILE"]}.lock"))

--- a/bin/generate_core_lockfile.rb
+++ b/bin/generate_core_lockfile.rb
@@ -10,7 +10,7 @@ FileUtils.cp("/mnt/Gemfile", "/tmp/lock_generator/")
 FileUtils.cp("/mnt/Gemfile.release.rb", "/tmp/lock_generator/bundler.d/") if File.file?("/mnt/Gemfile.release.rb")
 branch = Bundler.load.dependencies.detect { |i| i.name == "manageiq-api" }.branch
 puts "Bundling for branch: #{branch}..."
-exit $?.exitstatus unless system("git clone https://github.com/ManageIQ/manageiq-appliance.git -b #{branch} /tmp/manageiq-appliance")
+exit $?.exitstatus unless system("git clone --branch #{branch} --depth 1 https://github.com/ManageIQ/manageiq-appliance.git  /tmp/manageiq-appliance")
 FileUtils.cp("/tmp/manageiq-appliance/manageiq-appliance-dependencies.rb", "/tmp/lock_generator/bundler.d/")
 
 # Generate Gemfile.lock


### PR DESCRIPTION
Usage:
`podman run -it --rm -v projects/manageiq/manageiq:/mnt:z --entrypoint /build_scripts/bin/generate_core_lockfile.rb docker.io/manageiq/rpm_build:latest`

Generates:
- `bundler.d/Gemfile.release.rb` with locked down versions for all of the non-git non-dev/test gems
- `Gemfile.lock.release`