### PR TITLE
[MORPHY] Add manageiq-initialize.service to manageiq-system rpm

### DIFF
--- a/rpm_spec/subpackages/manageiq-system
+++ b/rpm_spec/subpackages/manageiq-system
@@ -36,6 +36,7 @@ Requires: openldap-clients
 %{_bindir}/pg_inspector_server.sh
 %{_prefix}/lib/systemd/system/cloud-ds-check.service
 %{_prefix}/lib/systemd/system/evm*
+%{_prefix}/lib/systemd/system/manageiq-initialize.service
 %{_prefix}/lib/systemd/system/miq*
 %{_sbindir}/ifup-local
 %{_sysconfdir}/cloud/cloud.cfg.d/10_miq_*.cfg


### PR DESCRIPTION
This was being included in the `manageiq-core-services` rpm subpackage on master because of the static systemd unit file changes where we prefix our workers with `manageiq-` e.g. `manageiq-generic@.service`.

This change isn't on morphy and as such we are hitting the following error during build:
```
    Installed (but unpackaged) file(s) found:
   /usr/lib/systemd/system/manageiq-initialize.service
Build step 'Execute shell' marked build as failure
```