### PR TITLE
Explicitly declare manageiq-appliance services

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -75,3 +75,11 @@ fi
 %defattr(-,root,root,-)
 %{_sysconfdir}/httpd/conf.d/manageiq-*
 %{_sysconfdir}/motd.manageiq
+%{_prefix}/lib/systemd/system/cloud-ds-check.service
+%{_prefix}/lib/systemd/system/evm-failover-monitor.service
+%{_prefix}/lib/systemd/system/evminit.service
+%{_prefix}/lib/systemd/system/evmserverd.service
+%{_prefix}/lib/systemd/system/manageiq-db-ready.service
+%{_prefix}/lib/systemd/system/manageiq-initialize.service
+%{_prefix}/lib/systemd/system/miqtop.service
+%{_prefix}/lib/systemd/system/miqvmstat.service

--- a/rpm_spec/subpackages/manageiq-core-services
+++ b/rpm_spec/subpackages/manageiq-core-services
@@ -20,4 +20,6 @@ done
 
 %files core-services
 %{_prefix}/lib/systemd/system/manageiq*
+%exclude %{_prefix}/lib/systemd/system/manageiq-db-ready.service
+%exclude %{_prefix}/lib/systemd/system/manageiq-initialize.service
 %exclude %{_prefix}/lib/systemd/system/manageiq-providers*

--- a/rpm_spec/subpackages/manageiq-system
+++ b/rpm_spec/subpackages/manageiq-system
@@ -33,14 +33,6 @@ Requires: openldap-clients
 %{_bindir}/miq*
 %{_bindir}/normalize_userid_to_upn
 %{_bindir}/pg_inspector_server.sh
-%{_prefix}/lib/systemd/system/cloud-ds-check.service
-%{_prefix}/lib/systemd/system/evm-failover-monitor.service
-%{_prefix}/lib/systemd/system/evminit.service
-%{_prefix}/lib/systemd/system/evmserverd.service
-%{_prefix}/lib/systemd/system/manageiq-db-ready.service
-%{_prefix}/lib/systemd/system/manageiq-initialize.service
-%{_prefix}/lib/systemd/system/miqtop.service
-%{_prefix}/lib/systemd/system/miqvmstat.service
 %{_sbindir}/ifup-local
 %{_sysconfdir}/cloud/cloud.cfg.d/10_miq_*.cfg
 %{_sysconfdir}/cron.hourly/miq*

--- a/rpm_spec/subpackages/manageiq-system
+++ b/rpm_spec/subpackages/manageiq-system
@@ -34,8 +34,13 @@ Requires: openldap-clients
 %{_bindir}/normalize_userid_to_upn
 %{_bindir}/pg_inspector_server.sh
 %{_prefix}/lib/systemd/system/cloud-ds-check.service
-%{_prefix}/lib/systemd/system/evm*
-%{_prefix}/lib/systemd/system/miq*
+%{_prefix}/lib/systemd/system/evm-failover-monitor.service
+%{_prefix}/lib/systemd/system/evminit.service
+%{_prefix}/lib/systemd/system/evmserverd.service
+%{_prefix}/lib/systemd/system/manageiq-db-ready.service
+%{_prefix}/lib/systemd/system/manageiq-initialize.service
+%{_prefix}/lib/systemd/system/miqtop.service
+%{_prefix}/lib/systemd/system/miqvmstat.service
 %{_sbindir}/ifup-local
 %{_sysconfdir}/cloud/cloud.cfg.d/10_miq_*.cfg
 %{_sysconfdir}/cron.hourly/miq*


### PR DESCRIPTION
There are a number of "base" systemd services that are needed to run the appliance version of manageiq.  These had been part of manageiq-system but that is pulled in to podified.  Also some services (e.g. manageiq-initialize.service) were being pulled in to the manageiq-core-services rpm with the rest of the worker services.

Explicitly declare the base appliance services and exclude them from the manageiq-core-services rpm