### PR TITLE
Only chown files if files exist

### DIFF
--- a/rpm_spec/subpackages/manageiq-ui
+++ b/rpm_spec/subpackages/manageiq-ui
@@ -11,7 +11,8 @@ Requires: mod_ssl
 # These files are not owned by the rpm.
 #  For upgrades, ensure they have the correct group privs
 #  so root and manageiq users can read them.
-%{__chown} -f manageiq.manageiq %{app_root}/public/{pictures,upload}/*
+if [[ -e %{app_root}/public/pictures/* ]]; then %{__chown} -f manageiq.manageiq %{app_root}/public/pictures/*; fi
+if [[ -e %{app_root}/public/upload/* ]]; then %{__chown} -f manageiq.manageiq %{app_root}/public/upload/*; fi
 
 %files ui
 %defattr(-,root,root,-)


### PR DESCRIPTION
Fix for chown -f returning 1 and causing the ui scriptlet to fail

```
[root@manageiq ~]# chown -f manageiq.manageiq /var/www/miq/vmdb/public/pictures/*
[root@manageiq ~]# echo $?
1
```

```
  Upgrading        : manageiq-ui-14.0.0-20210916191227.el8.x86_64                                                                                                                             5/18 
  Running scriptlet: manageiq-ui-14.0.0-20210916191227.el8.x86_64                                                                                                                             5/18 
warning: %post(manageiq-ui-14.0.0-20210916191227.el8.x86_64) scriptlet failed, exit status 1

Error in POSTIN scriptlet in rpm package manageiq-ui
  Upgrading        : manageiq-gemset-services-14.0.0-20210916191227.el8.x86_64  
```

Fixes https://github.com/ManageIQ/manageiq-rpm_build/issues/186