### PR TITLE
[MORPHY] Add back missing evm-watchdog.service

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -96,6 +96,7 @@ fi
 %{_sysconfdir}/motd.manageiq
 %{_prefix}/lib/systemd/system/cloud-ds-check.service
 %{_prefix}/lib/systemd/system/evm-failover-monitor.service
+%{_prefix}/lib/systemd/system/evm-watchdog.service
 %{_prefix}/lib/systemd/system/evminit.service
 %{_prefix}/lib/systemd/system/evmserverd.service
 %{_prefix}/lib/systemd/system/manageiq-initialize.service


### PR DESCRIPTION
Removed `manageiq-db-ready.service` but forgot to put back `evm-watchdog.service`

Follow-up to https://github.com/ManageIQ/manageiq-rpm_build/pull/196

```
    Installed (but unpackaged) file(s) found:
   /usr/lib/systemd/system/evm-watchdog.service
Build step 'Execute shell' marked build as failure
```