### PR TITLE
Prefer using npm.manageiq.org as a proxy cache for yarn

### DIFF
--- a/config/options.yml
+++ b/config/options.yml
@@ -22,7 +22,7 @@ rpm:
   product_url:     https://github.com/ManageIQ/manageiq
   changelog:
 bundler_version:   2.1.4
-npm_registry:
+npm_registry:      https://npm.manageiq.org
 rpm_repository:
   digitalocean_access_token:
   s3_api:


### PR DESCRIPTION
This should reduce throttling and timeout issues during builds

Sample error:
```
[3/5] Fetching packages...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
error An unexpected error occurred: "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz: ESOCKETTIMEDOUT".
info If you think this is a bug, please open a bug report with the information provided in "/root/BUILD/manageiq-gemset-14.0.0/bundler/gems/manageiq-providers-nsxt-d0c7629b7b3f/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...

== yarn failed in /root/BUILD/manageiq-gemset-14.0.0/bundler/gems/manageiq-providers-nsxt-d0c7629b7b3f ==
```