### PR TITLE
[MORPHY] hardcode gem_path and path

### DIFF
--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -51,13 +51,13 @@ cat <<"EOF" > %{gemset_builddir}/enable
 export APPLIANCE="true"
 export BUNDLE_GEMFILE=%{app_root}/Gemfile
 export GEM_HOME=%{gemset_root}
-export GEM_PATH=%{gemset_root}:$(gem env path)
-export PATH=%{gemset_root}/bin:$PATH
+export GEM_PATH=%{gemset_root}:/usr/share/gems:/usr/local/share/gems
+export PATH=%{gemset_root}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 EOF
 
 cat <<"EOF" > %{appliance_builddir}/LINK/etc/default/evm_production
 export APPLIANCE_SOURCE_DIRECTORY=%{appliance_root}
-export APPLIANCE_TEMPLATE_DIRECTORY=${APPLIANCE_SOURCE_DIRECTORY}/TEMPLATE
+export APPLIANCE_TEMPLATE_DIRECTORY=%{appliance_root}/TEMPLATE
 source %{gemset_root}/enable
 EOF
 


### PR DESCRIPTION
Part of issue: https://github.com/ManageIQ/manageiq-pods/issues/695
backporting: https://github.com/ManageIQ/manageiq-rpm_build/pull/145

shelling out to gem env path is taking too long.
It is also not possible to convert this into a properties file

These files are only used for running manageiq. so locking down the values should not be a problem.
If we go the route of installing rpms on other people's appliances, then we will need to reevaluate

---

This is minor risk and is >80% of the time for `env` (which we use to load our environment in all scripts and shells)