### PR TITLE
Revert "Move initial bundle into the Docker image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,6 @@ RUN if [ ${ARCH} = "s390x" ] || [ ${ARCH} = "ppc64le" ] ; then dnf -y install py
 RUN npm install yarn -g
 
 RUN echo "gem: --no-ri --no-rdoc --no-document" > /root/.gemrc
-COPY Gemfile /build_scripts/Gemfile
-RUN cd /build_scripts && bundle
 
 COPY . /build_scripts
 

--- a/container-assets/user-entrypoint.sh
+++ b/container-assets/user-entrypoint.sh
@@ -15,4 +15,5 @@ else
 fi
 
 cd /build_scripts
+bundle
 $cmd


### PR DESCRIPTION
This reverts commit 30a904f4cab6cce853697b4e0cdc2c76db44e206.

This issue was introduced by #212 .  Reverting until we can solve it completely.

```
---> find "$GEM_HOME/specifications" -type l -xtype l -delete
/build_scripts/lib/manageiq/rpm_build/generate_core.rb:75:in `populate': Error: /root/BUILD/manageiq-gemset-14.0.0/bin/rake should be used, but /bin/rake is being used instead. (RuntimeError)
	from bin/build.rb:29:in `<main>'
```