### PR TITLE
Fix ppc64 and s390x builds that need python 2.7

### DIFF
--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -83,7 +83,7 @@ module ManageIQ
 
           # HACK: Use Python 2.7 for ppc64 and s390x
           # TODO: Find out why...
-          shell_cmd("npm config --global set python /usr/bin/python2.7") if RUBY_PLATFORM.split("-").first != "x86_64"
+          shell_cmd("npm config --global set python /usr/bin/python2.7") if Gem::Platform.local.cpu != "x86_64"
 
           shell_cmd("rake update:ui")
 


### PR DESCRIPTION
Building on PPC fails without this?

```
Building wheel for pycurl (setup.py): started
  Building wheel for pycurl (setup.py): finished with status 'error'
[91m  ERROR: Command errored out with exit status 1:
   command: /var/lib/manageiq/venv/bin/python -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-zrwlgk0o/pycurl_d848e9e4cc5a428bac4057740eee7590/setup.py'"'"'; __file__='"'"'/tmp/pip-install-zrwlgk0o/pycurl_d848e9e4cc5a428bac4057740eee7590/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-ije_609m
       cwd: /tmp/pip-install-zrwlgk0o/pycurl_d848e9e4cc5a428bac4057740eee7590/
  Complete output (20 lines):
  Using curl-config (libcurl 7.61.1)
  Using SSL library: OpenSSL/LibreSSL/BoringSSL
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-3.6
  creating build/lib.linux-x86_64-3.6/curl
  copying python/curl/__init__.py -> build/lib.linux-x86_64-3.6/curl
  running build_ext
  building 'pycurl' extension
  creating build/temp.linux-x86_64-3.6
  creating build/temp.linux-x86_64-3.6/src
  gcc -pthread -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -fPIC -DPYCURL_VERSION="7.44.1" -DHAVE_CURL_SSL=1 -DHAVE_CURL_OPENSSL=1 -DHAVE_CURL_SSL=1 -I/var/lib/manageiq/venv/include -I/usr/include/python3.6m -c src/docstrings.c -o build/temp.linux-x86_64-3.6/src/docstrings.o
  In file included from src/docstrings.c:4:
  src/pycurl.h:178:13: fatal error: openssl/ssl.h: No such file or directory
   #   include <openssl/ssl.h>
               ^~~~~~~~~~~~~~~
  compilation terminated.
  error: command 'gcc' failed with exit status 1
  ----------------------------------------
[0m[91m  ERROR: Failed building wheel for pycurl
[0m  Running setup.py clean for pycurl
Successfully built applicationinsights backports.ssl-match-hostname dogpile.cache ipaddress munch ncclient netifaces oauthlib os-service-types ovirt-engine-sdk-python pycparser pykerberos
Failed to build pycurl
```