### PR TITLE
declare rpm dependencies for creating user

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -14,12 +14,14 @@ Requires: net-snmp
 Requires: net-snmp-libs
 Requires: net-snmp-utils
 Requires: socat
+Requires: core-utils
+Requires: shadow-utils
 
 %description core
 %{product_summary} Core
 
 %pre core
-# ensure this user exists (build and upgrade)
+# if this user does not exist, then add them (with no password or home directory)
 /usr/bin/id manageiq > /dev/null 2>&1 || /usr/sbin/useradd --system manageiq
 
 %posttrans core


### PR DESCRIPTION
Attempting to address: https://github.com/ManageIQ/manageiq-rpm_build/issues/219

We create a manageiq user to properly setup
permissions as the manageiq (non-root) user

There were some hints from https://access.redhat.com/solutions/5749321
Missing dependencies seems to be a common `rpm` fail, especially when the dependencies are low level. The kickstarter file is probably the only case that something like this will fail.

These are basic dependencies, shadow is how we create all users and core-utils is well, basic stuff like `cp` and `ln` (one of the reasons I went with `id` instead of `getent` (glibc-common which is probably just as low level)

I have not built nor installed this. But as of recently I can no longer install self compiled manageiq rpms so it is beyond me to test.