### PR TITLE
fix chmod cleanup

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -35,15 +35,19 @@ do
 done
 
 %post core
-# These files are not owned by the rpm.
-#  For upgrades, ensure they have the correct group privs
+# These directories contain files not owned by this rpm.
+#  For upgrades, ensure the files have the correct group privs
 #  so root and manageiq users can read them.
-%{__chown} -f manageiq.manageiq %{app_root}/certs/v2_key %{app_root}/log/*.log
-%{__chown} -f manageiq.manageiq %{app_root}/tmp/pids/*.pid %{app_root}/config/*.yml
+[ -e %{app_root}/certs/v2_key ] && %{__chown} manageiq.manageiq %{app_root}/certs/v2_key
+[ -e %{app_root}/certs/v2_key ] && %{__chmod} o-rw %{app_root}/certs/v2_key
+
+%{__chown} -R manageiq.manageiq %{app_root}/log
+%{__chmod} -R o-rw %{app_root}/log
+
+%{__chown} -R manageiq.manageiq %{app_root}/tmp/pids
+%{__chmod} -R o-rw %{app_root}/tmp/pids
+
 %{__chown} -R manageiq.manageiq %{app_root}/data
-%{__chmod} -f o-rw %{app_root}/certs/v2_key
-%{__chmod} -f o-rw %{app_root}/config/*.yml %{app_root}/tmp/pids/*.pid
-%{__chmod} -f o-rw %{app_root}/log/*.log
 
 %files core
 %defattr(-,root,root,-)


### PR DESCRIPTION
Attempting to address: #219

Change the way we clean up external files
to ensure we are issuing commands on
files that exist

No longer modify yaml files
This was originally an over generalization for cable, database and messaging.yml