### PR TITLE
Remove subscription-manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV TERM=xterm \
     APPLIANCE=true \
     RAILS_USE_MEMORY_STORE=true
 
-RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/subscription-manager.conf && \
+RUN dnf -y remove subscription-manager* && \
     dnf -y update && \
     curl -L https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo > /etc/yum.repos.d/ansible-runner.repo && \
     ARCH=$(uname -m) && \


### PR DESCRIPTION
- We don't use it
- It's also causing conflicts
```
Error:
 Problem 1: cannot install the best update candidate for package python3-subscription-manager-rhsm-1.28.13-4.el8_4.x86_64
  - nothing provides python3-cloud-what = 1.28.21-3.el8 needed by python3-subscription-manager-rhsm-1.28.21-3.el8.x86_64
 Problem 2: package python3-subscription-manager-rhsm-1.28.13-4.el8_4.x86_64 requires subscription-manager-rhsm-certificates = 1.28.13-4.el8_4, but none of the providers can be installed
  - cannot install both subscription-manager-rhsm-certificates-1.28.21-3.el8.x86_64 and subscription-manager-rhsm-certificates-1.28.13-4.el8_4.x86_64
  - problem with installed package python3-subscription-manager-rhsm-1.28.13-4.el8_4.x86_64
  - cannot install the best update candidate for package subscription-manager-rhsm-certificates-1.28.13-4.el8_4.x86_64
  - nothing provides python3-cloud-what = 1.28.21-3.el8 needed by python3-subscription-manager-rhsm-1.28.21-3.el8.x86_64
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```