### PR TITLE
[WIP] Without bundler, config gem can't be found

### DIFF
--- a/bin/build.rb
+++ b/bin/build.rb
@@ -2,6 +2,7 @@
 
 $LOAD_PATH << File.expand_path("../lib", __dir__)
 
+require 'bundler/setup'
 require 'manageiq/rpm_build'
 require 'optimist'
 


### PR DESCRIPTION
```
...
Using config 3.1.0
Using manageiq-style 1.3.1
Using railties 6.1.4.1
Using rspec-rails 4.1.2
Bundle complete! 10 Gemfile dependencies, 89 gems now installed.
Bundled gems are installed into `./vendor/bundle`
[root@64fb877aa795 build_scripts]# bundle show config
/build_scripts/vendor/bundle/ruby/2.6.0/gems/config-3.1.0
[root@64fb877aa795 build_scripts]# bin/build.rb
/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- config (LoadError)
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /build_scripts/lib/manageiq/rpm_build.rb:1:in `<top (required)>'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
	from bin/build.rb:5:in `<main>'
[root@64fb877aa795 build_scripts]# bundle show config
/build_scripts/vendor/bundle/ruby/2.6.0/gems/config-3.1.0
```