### PR TITLE
Fix active_support require

### DIFF
--- a/lib/manageiq/rpm_build/generate_core.rb
+++ b/lib/manageiq/rpm_build/generate_core.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'pathname'
 require 'yaml'
+require 'active_support'
 require 'active_support/core_ext/time/calculations' # Required for Time#change
 
 module ManageIQ


### PR DESCRIPTION
Before loading subsets of active_support, you are supposed to `require "active_support"` first.  See https://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support