### PR TITLE
Lockdown bundler due to build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,6 @@ RUN echo "gem: --no-ri --no-rdoc --no-document" > /root/.gemrc
 
 COPY . /build_scripts
 
-RUN gem install bundler
+RUN gem install bundler:2.3.4
 
 ENTRYPOINT ["/build_scripts/container-assets/user-entrypoint.sh"]


### PR DESCRIPTION
Temporarily lock down bundler to 2.3.4 until
https://github.com/rubygems/rubygems/pull/5291 is released

@bdunne Please review.