### PR TITLE
[MORPHY] Ensure $GEM_HOME exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN dnf -y remove subscription-manager* && \
       qpid-proton-c-devel \
       ruby-devel \
       wget && \
+    mkdir -p /root/.gem/ruby # $GEM_HOME && \
     dnf -y update libarchive && \
     dnf clean all
 


### PR DESCRIPTION
Previously this was failing with:
```
Using config 3.1.1
Using rspec-rails 4.1.2
Installing aws-partitions 1.550.0
Using aws-sdk-core 3.125.5
Using aws-sdk-kms 1.53.0
Fetching aws-sdk-s3 1.111.3
Installing aws-sdk-s3 1.111.3
Bundle complete! 10 Gemfile dependencies, 81 gems now installed.
Bundled gems are installed into `./vendor/bundle`
/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- config (LoadError)
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /build_scripts/lib/manageiq/rpm_build.rb:1:in `<top (required)>'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
	from bin/build.rb:5:in `<main>'
```