### PR TITLE
[NAJDORF] Drop kafka dependency due to log4j security issues

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -12,8 +12,6 @@ Requires: repmgr10 >= 4.0.6
 Requires: lvm2
 Requires: memcached
 
-Requires: kafka
-
 # NTP
 Requires: chrony
 


### PR DESCRIPTION
Since we're not depending on kafka right now, drop the dependency to avoid issues from security scanners.

I assume we want to keep this on master so I targeted najdorf here.