### PR TITLE
Build the ARCH and Source RPMs

### DIFF
--- a/lib/manageiq/rpm_build/build_copr.rb
+++ b/lib/manageiq/rpm_build/build_copr.rb
@@ -26,7 +26,8 @@ module ManageIQ
             shell_cmd("rpmbuild -bs --define '_sourcedir #{RPM_SPEC_DIR}' --define '_srcrpmdir #{RPM_SPEC_DIR}' #{rpm_spec}")
             shell_cmd("copr-cli build -r epel-8-x86_64 #{rpm_repo_name} #{OPTIONS.product_name}-*.src.rpm")
           else
-            shell_cmd("rpmbuild -bb --define '_sourcedir #{RPM_SPEC_DIR}' --define '_rpmdir #{BUILD_DIR.join("rpms")}' #{rpm_spec}")
+            arch = RUBY_PLATFORM.split("-").first
+            shell_cmd("rpmbuild -ba --define '_sourcedir #{RPM_SPEC_DIR}' --define '_srcrpmdir #{BUILD_DIR.join("rpms", arch)}' --define '_rpmdir #{BUILD_DIR.join("rpms")}' #{rpm_spec}")
           end
         end
       end


### PR DESCRIPTION
SRPMs are hepful when we need to create hotfixes since they contain sources and the RPM spec, then we can add any patches and rebuild the RPMs.
Otherwise we need to start over with the whole tar generation process (including bundling the gems)

This results in:
```
Wrote: /root/BUILD/rpms/x86_64/manageiq-13.1.0-20220218221933.el8.src.rpm
Wrote: /root/BUILD/rpms/x86_64/manageiq-appliance-13.1.0-20220218221933.el8.x86_64.rpm
Wrote: /root/BUILD/rpms/x86_64/manageiq-appliance-tools-13.1.0-20220218221933.el8.x86_64.rpm
Wrote: /root/BUILD/rpms/x86_64/manageiq-core-13.1.0-20220218221933.el8.x86_64.rpm
Wrote: /root/BUILD/rpms/x86_64/manageiq-gemset-13.1.0-20220218221933.el8.x86_64.rpm
Wrote: /root/BUILD/rpms/x86_64/manageiq-pods-13.1.0-20220218221933.el8.x86_64.rpm
Wrote: /root/BUILD/rpms/x86_64/manageiq-system-13.1.0-20220218221933.el8.x86_64.rpm
Wrote: /root/BUILD/rpms/x86_64/manageiq-ui-13.1.0-20220218221933.el8.x86_64.rpm
```