### PR TITLE
Skip symlinks in gems dir when copying systemd files

### DIFF
--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -90,7 +90,13 @@ cd %{_builddir}
 # Copy systemd unit files
 %{__mkdir} -p %{buildroot}%{_prefix}/lib/systemd/system
 %{__cp} -a %{core_builddir}/systemd/* %{buildroot}/%{_prefix}/lib/systemd/system
-%{__cp} -a %{gemset_builddir}/bundler/gems/*/systemd/* %{buildroot}/%{_prefix}/lib/systemd/system
+for gem_dir in %{gemset_builddir}/bundler/gems/*
+do
+  if [[ ! -L $gem_dir ]]
+  then
+    [[ -e $gem_dir/systemd ]] && %{__cp} -a $gem_dir/systemd/* %{buildroot}/%{_prefix}/lib/systemd/system
+  fi
+done
 
 ### from manifest
 %{__mkdir} -p %{buildroot}%{manifest_root}


### PR DESCRIPTION
Prevent duplication of systemd unit/targets when copying from gems