### PR TITLE
Set yarn version to 1.22.18 for s390x platform

### DIFF
--- a/lib/manageiq/rpm_build/generate_core.rb
+++ b/lib/manageiq/rpm_build/generate_core.rb
@@ -57,6 +57,7 @@ module ManageIQ
           if RUBY_PLATFORM.match?(/powerpc64le|s390x/)
             shell_cmd("npm config --global set python /usr/bin/python2.7")
           end
+          system("yarn set version 1.22.18") || abort("\n== yarn failed to set version to 1.22.18 in #{engine.path} ==") if RUBY_PLATFORM.include?("s390x")
           shell_cmd("yarn install")
           shell_cmd("yarn run available-languages")
           shell_cmd("yarn run build")


### PR DESCRIPTION
Hi @Fryguy ,

Raising this PR to update the yarn version to 1.22.18 as we faced issue with yarn version 3.0.2 when it's going to run **yarn install** command then it stucks at  **babel/plugin-proposal-class-properties** package
 `➤ YN0013: │ @babel/plugin-proposal-class-properties@npm:7.14.5 can't be found in the cache and will be fetched from the remote registry`
 
With this PR changes , build went pass through **yarn install** phase smoothly
```
---> yarn install
yarn install v1.22.18
[1/5] Validating package.json...
[2/5] Resolving packages...
warning @manageiq/ui-components > angular-bootstrap-switch > angular@1.8.3: For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.
---------------------
https://github.com/lydell/source-map-resolve#deprecated
warning webpack-dev-server > url > querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
[3/5] Fetching packages...
[4/5] Linking dependencies...
warning "bootstrap-combobox > bootstrap@5.1.3" has unmet peer dependency "@popperjs/core@^2.10.2".
warning " > bootstrap-switch@3.4.0" has unmet peer dependency "bootstrap@^4.3.1".
warning " > postcss-loader@4.0.4" has unmet peer dependency "postcss@^7.0.0 || ^8.0.1".
[5/5] Building fresh packages...
success Saved lockfile.
Done in 263.46s.
```
