### PR TITLE
disable git clean on s390x

### DIFF
--- a/lib/manageiq/rpm_build/generate_core.rb
+++ b/lib/manageiq/rpm_build/generate_core.rb
@@ -61,7 +61,7 @@ module ManageIQ
           shell_cmd("yarn install")
           shell_cmd("yarn run available-languages")
           shell_cmd("yarn run build")
-          shell_cmd("git clean -xdf")  # cleanup temp files
+          shell_cmd("git clean -xdf") if !RUBY_PLATFORM.include?("s390x") 
         end
       end
 

--- a/lib/manageiq/rpm_build/generate_core.rb
+++ b/lib/manageiq/rpm_build/generate_core.rb
@@ -61,7 +61,7 @@ module ManageIQ
           shell_cmd("yarn install")
           shell_cmd("yarn run available-languages")
           shell_cmd("yarn run build")
-          shell_cmd("git clean -xdf") if !RUBY_PLATFORM.include?("s390x") 
+          shell_cmd("git clean -xdf") unless RUBY_PLATFORM.include?("s390x")
         end
       end
 


### PR DESCRIPTION
Hi @Fryguy ,
 
 Raised this PR to disable the git clean on z platform as we have faced an issue with license_finder trying to find yarn version 1.22.18 which has been removed by `git clean -xdf` command  
```
 /root/BUILD/manageiq-gemset-15.0.0/gems/license_finder-7.0.1/lib/license_finder/package_managers/yarn.rb:90:in `block in yarn_version': Command 'yarn -v' failed to execute: internal/modules/cjs/loader.js:905 (RuntimeError)
  throw err;
  ^

Error: Cannot find module '/root/BUILD/manageiq-ui-service/.yarn/releases/yarn-1.22.18.cjs'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```