### PR TITLE
Make nodejs a build require

### DIFF
--- a/rpm_spec/subpackages/manageiq-gemset
+++ b/rpm_spec/subpackages/manageiq-gemset
@@ -1,6 +1,7 @@
 %package gemset
 Summary: %{product_summary} Gemset
 BuildRequires: /usr/bin/pathfix.py
+BuildRequires: nodejs
 
 Requires: cifs-utils
 Requires: libpq
@@ -12,7 +13,6 @@ Requires: libxslt
 Requires: nfs-utils
 Requires: openscap-scanner
 Requires: openssl
-Requires: nodejs
 
 %ifarch x86_64
 Requires: wmi

--- a/rpm_spec/subpackages/manageiq-ui
+++ b/rpm_spec/subpackages/manageiq-ui
@@ -1,5 +1,6 @@
 %package ui
 Summary: %{product_summary} UI
+BuildRequires: nodejs
 Requires: %{name}-core = %{version}-%{release}
 Requires: httpd
 Requires: mod_ssl


### PR DESCRIPTION
Remove the runtime dependency on nodejs

Part of: https://github.com/ManageIQ/manageiq-ui-classic/issues/8300

NOTE: See https://github.com/ManageIQ/manageiq-ui-classic/issues/8300 for the breakdown of required PRs.