### PR TITLE
Add more manifests for non-gem repos

### DIFF
--- a/lib/manageiq/rpm_build.rb
+++ b/lib/manageiq/rpm_build.rb
@@ -25,6 +25,7 @@ module ManageIQ
 
     BUILD_DIR    = Pathname.new(ENV.fetch("BUILD_DIR", "~/BUILD")).expand_path
     RPM_SPEC_DIR = BUILD_DIR.join("rpm_spec")
+    MANIFEST_DIR = BUILD_DIR.join("manifest")
 
     OPTIONS_DIR  = Pathname.new(ENV.fetch("OPTIONS_DIR", "~/OPTIONS")).expand_path
     OPTIONS      = Config.load_files(CONFIG_DIR.join("options.yml"), OPTIONS_DIR.join("options.yml"))

--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -12,7 +12,7 @@ module ManageIQ
 
       def initialize
         where_am_i
-        @manifest_dir    = BUILD_DIR.join("manifest")
+        @manifest_dir    = MANIFEST_DIR
         @miq_dir         = BUILD_DIR.join("manageiq")
       end
 
@@ -109,8 +109,7 @@ module ManageIQ
       def generate_dependency_manifest
         where_am_i
 
-        FileUtils.rm_rf(manifest_dir) if manifest_dir.exist?
-        FileUtils.mkdir(manifest_dir)
+        FileUtils.mkdir_p(manifest_dir)
 
         shell_cmd("gem install license_finder")
         generate_gem_manifest

--- a/lib/manageiq/rpm_build/generate_tar_files.rb
+++ b/lib/manageiq/rpm_build/generate_tar_files.rb
@@ -46,6 +46,7 @@ module ManageIQ
         name = "manifest"
         shell_cmd("tar -C #{BUILD_DIR.join(name)} #{transform(name)} --exclude='.git' -hzcf #{tar_full_path(name)} .")
       end
+
       private
 
       def exclude_file(tarball_name)

--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -88,3 +88,4 @@ fi
 %{_prefix}/lib/systemd/system/manageiq-initialize.service
 %{_prefix}/lib/systemd/system/miqtop.service
 %{_prefix}/lib/systemd/system/miqvmstat.service
+%{manifest_root}/BUILD_APPLIANCE

--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -61,4 +61,6 @@ done
 %exclude %{app_root}/public/ui
 %exclude %{app_root}/public/upload
 %exclude %{app_root}/log/apache
+%{manifest_root}/BUILD
+%{manifest_root}/BUILD_RPM_BUILD
 /usr/share/ansible/roles/

--- a/rpm_spec/subpackages/manageiq-ui
+++ b/rpm_spec/subpackages/manageiq-ui
@@ -22,6 +22,7 @@ if [[ -e %{app_root}/public/upload/* ]]; then %{__chown} -f manageiq.manageiq %{
 %{app_root}/public/assets
 %{app_root}/public/packs
 %{app_root}/public/ui
+%{manifest_root}/BUILD_UI_SERVICE
 %{manifest_root}/npm_manifest.csv
 %{manifest_root}/webpack_modules_manifest.json
 %{manifest_root}/webpack_packages_manifest.json


### PR DESCRIPTION
This PR creates a copy of the BUILD file that's normally in /var/www/miq/vmdb in the /opt/manageiq/manifests directory, and then adds additional BUILD_ files for non-gem repos that we normally don't get any information for.  gem repos and their SHAs already exist in /opt/manageiq/manifests/gen_manifest.csv.

@jrafanie Please review.