### PR TITLE
Update kafka to 3.2.0

### DIFF
--- a/config/options.yml
+++ b/config/options.yml
@@ -40,7 +40,7 @@ rpm_repository:
       :targets:
         - el8
       :rpms:
-        :kafka: !ruby/regexp /.+-2\.3.+/
+        :kafka: !ruby/regexp /.+-3\.2.+/
         :manageiq: !ruby/regexp /.+-15\.\d\.\d-(alpha|beta|rc)?\d(\.\d)?\.el.+/
         :manageiq-release: !ruby/regexp /.+-15\.0.+/
         :python-bambou: !ruby/regexp /.+-3\.1\.1.+/

--- a/packages/kafka/kafka.spec
+++ b/packages/kafka/kafka.spec
@@ -1,7 +1,7 @@
 Name:             kafka
 Summary:          Apache Kafka is an open-source stream-processing software platform
-Version:          2.3.1
-Release:          2%{?dist}
+Version:          3.2.0
+Release:          1%{?dist}
 License:          Apache (v2)
 Group:            Applications
 URL:              https://kafka.apache.org
@@ -20,7 +20,7 @@ BuildRoot:        %{_tmppath}/%{name}-%{version}-root
 
 %global debug_package %{nil}
 %define __jar_repack 0
-%define gradle_version 5.6.4
+%define gradle_version 7.4.2
 %define kafka_home /opt/kafka
 %define kafka_group %{name}
 %define kafka_user %{name}

--- a/packages/kafka/kafka.spec
+++ b/packages/kafka/kafka.spec
@@ -108,6 +108,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Fri Jul 08 2022 "Adam Grare" <adam@grare.com> - 3.2.0-1
+- Upgrade to v3.2.0
+
 * Wed Nov 11 2020 "Brandon Dunne" <bdunne@redhat.com> - 2.3.1-2
 - Copy modified server.properties and zookeeper.properties config files to config-sample
 


### PR DESCRIPTION
According to https://downloads.apache.org/kafka/3.2.0/RELEASE_NOTES.html kafka v3.2 has completely dropped log4j in favor of reload4j (https://issues.apache.org/jira/browse/KAFKA-13660)