### PR TITLE
Include weak dependencies of Ruby that we actually need

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -2,6 +2,12 @@
 Summary:  %{product_summary} Core
 
 Requires: ruby
+# Include weak dependencies of Ruby that we actually need
+Requires: ruby-default-gems
+Requires: rubygem-bigdecimal
+Requires: rubygem-io-console
+Requires: rubygem-irb
+
 Requires: %{name}-gemset = %{version}-%{release}
 
 Requires: ansible


### PR DESCRIPTION
The ruby module declares a number of dependencies as weak dependencies, including:  ruby-default-gems, rubygem-bigdecimal, rubygem-io-console, and rubygem-rdoc.  Additionally, rubygem-irb is considered weak as it's a dependency of rubygem-rdoc.

If weak dependencies are excluded, these will not be installed, but ManageIQ depends on them, so this change makes the ones we need actually required.  The PR does _not_ require the following weak gems as we either don't need them or have newer versions in the gemset: rubygem-bundler-2.2.24, rubygem-json-2.3.0, and rubygem-rdoc-6.2.1.1 

This can be merged independently of https://github.com/ManageIQ/manageiq-pods/pull/846
