### PR TITLE
Build rugged with ssh support

### DIFF
--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -68,6 +68,7 @@ module ManageIQ
           end
 
           shell_cmd("bundle config set --local with qpid_proton systemd")
+          shell_cmd("bundle config set --local build.rugged --with-ssh")
 
           lock_release = miq_dir.join("Gemfile.lock.release")
           if lock_release.exist?


### PR DESCRIPTION
Rugged v1.4 disabled SSH support by default.  Rugged v1.5.0 added a `--with-ssh` build option to allow this to be enabled via `bundle config`

Depends on:
- [ ] https://github.com/ManageIQ/manageiq/pull/22006