### PR TITLE
Remove manageiq-initialize.service from rpm specs

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -85,7 +85,6 @@ fi
 %{_prefix}/lib/systemd/system/evminit.service
 %{_prefix}/lib/systemd/system/evmserverd.service
 %{_prefix}/lib/systemd/system/manageiq-db-ready.service
-%{_prefix}/lib/systemd/system/manageiq-initialize.service
 %{_prefix}/lib/systemd/system/miqtop.service
 %{_prefix}/lib/systemd/system/miqvmstat.service
 %{manifest_root}/BUILD_APPLIANCE

--- a/rpm_spec/subpackages/manageiq-core-services
+++ b/rpm_spec/subpackages/manageiq-core-services
@@ -21,5 +21,4 @@ done
 %files core-services
 %{_prefix}/lib/systemd/system/manageiq*
 %exclude %{_prefix}/lib/systemd/system/manageiq-db-ready.service
-%exclude %{_prefix}/lib/systemd/system/manageiq-initialize.service
 %exclude %{_prefix}/lib/systemd/system/manageiq-providers*


### PR DESCRIPTION
The manageiq-initailize.service automatically configures appliances as all-in-one with a database region configured.  This was dropped in https://github.com/ManageIQ/manageiq-appliance/pull/359 and should be removed from the rpm_spec