### PR TITLE
[WIP] make old certs readable by manageiq user

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -35,8 +35,8 @@ done
 # These directories contain files not owned by this rpm.
 #  For upgrades, ensure the files have the correct group privs
 #  so root and manageiq users can read them.
-[ -e %{app_root}/certs/v2_key ] && %{__chown} manageiq.manageiq %{app_root}/certs/v2_key
-[ -e %{app_root}/certs/v2_key ] && %{__chmod} o-rw %{app_root}/certs/v2_key
+[ -e %{app_root}/certs/v2_key ] && %{__chown} manageiq.manageiq %{app_root}/certs/*
+[ -e %{app_root}/certs/v2_key ] && %{__chmod} o-rw %{app_root}/certs/*
 
 %{__chown} -R manageiq.manageiq %{app_root}/log
 %{__chmod} -R o-rw %{app_root}/log


### PR DESCRIPTION
### Background

The ssl certificates are created outside the rpm
Older installations had root own all files.
So there were no permissions issues.

Now (for some time), most processes are run by manageiq user.
So to make things work better for the end user, we change the
permissions of critical (and sensitive) files to be restrictive
but readable by manageiq.manageiq

### Bug

v2_key was converted to be read by `manageiq` user, but ssl certificates were not.
Webconsole is broken because it needs to read the ssl certificate key.

### Solution

Make all certificates readable by `manageiq` user.
Issue raised in https://github.com/ManageIQ/manageiq/discussions/22060

### Limitations

Assumes that there will not be an ssl key without a `v2_key`.
Since nothing works without a `v2_key`, we can choose this single file to detect.
reminder: `[ -e certs/* ]` generates an error if there is more than one file in the directory: `-bash: [: too many arguments` error.