### PR TITLE
LicenseFinder ignore dev and test bundler groups

### DIFF
--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -138,6 +138,9 @@ module ManageIQ
       def run_license_finder(repos, type)
         where_am_i
 
+        shell_cmd("license_finder ignored_groups add development")
+        shell_cmd("license_finder ignored_groups add test")
+
         output  = manifest_dir.join("#{type}_manifest.csv")
         columns = "name version licenses"
         shell_cmd("license_finder report --format csv --write-headers --aggregate-paths #{repos} --columns #{columns} --save #{output}")


### PR DESCRIPTION
Now that conditionals have been removed from the core Gemfile, all dependencies are listed in the Gemfile.lock.  License Finder does not load the bundler "without", so we have to tell it to also ignore those dependencies otherwise it will try to materialize those gems (which are not installed)

Example error:
```
gems/bundler-2.3.21/lib/bundler/definition.rb:520:in `materialize': Could not find foreman-0.87.2, manageiq-style-1.2.0, PoParser-3.2.6, ... in locally installed gems (Bundler::GemNotFound)
```