### PR TITLE
Don't add anything in rpm_cache directory to the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 /BUILD/
 /OPTIONS/
+/rpm_cache/
 Gemfile.lock


### PR DESCRIPTION
This could cause the image to be enormous