### PR TITLE
Remove vendored jquery 1.x

### DIFF
--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -164,6 +164,9 @@ module ManageIQ
           # Vendored libgit2 isn't needed once the gem is compiled
           FileUtils.rm_rf(Dir.glob("gems/rugged-*/vendor"))
 
+          # Vendored jquery 1.x has security issues caught by scanners, but isn't used by the application
+          FileUtils.rm_rf(Dir.glob("gems/jquery-rails-*/vendor/assets/javascripts/jquery.*"))
+
           # Remove files with inappropriate license
           FileUtils.rm_rf(Dir.glob("gems/pdf-writer-*/demo")) # Creative Commons Attribution NonCommercial
 


### PR DESCRIPTION
Vendored jquery 1.x has security issues caught by scanners, but isn't used by the application

@DavidResende0 @bdunne Please review.