### PR TITLE
Add a nightly rpm build script

### DIFF
--- a/.github/workflows/build_rpms.yaml
+++ b/.github/workflows/build_rpms.yaml
@@ -29,3 +29,17 @@ jobs:
       run: |
         echo $REGISTRY_PASSWORD | docker login docker.io --password-stdin --username $REGISTRY_USERNAME
         docker run docker.io/manageiq/rpm_build:latest build --build-type nightly
+  notify_builders:
+    needs: build_rpms
+    runs-on: ubuntu-latest
+    steps:
+    - name: Notify manageiq-pods on RPM build
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.DEPLOY_TOKEN }}
+        repository: ManageIQ/manageiq-pods
+        event-type: build
+        client-payload: |
+          { "repository": "${{ github.repository }}",
+            "ref_name": "${{ github.ref_name }}",
+            "sha": "${{ github.sha }}" }

--- a/.github/workflows/build_rpms.yaml
+++ b/.github/workflows/build_rpms.yaml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   build_rpm_build_container:
+    if: github.repository_owner == 'ManageIQ'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up registry credentials
-      if: ${{ github.event_name != 'pull_request' }}
       run: |
         echo "REGISTRY_USERNAME=${{ secrets.REGISTRY_USERNAME }}" >> $GITHUB_ENV
         echo "REGISTRY_PASSWORD=${{ secrets.REGISTRY_PASSWORD }}" >> $GITHUB_ENV
@@ -19,6 +19,7 @@ jobs:
       run: bin/build_container_image
   build_rpms:
     needs: build_rpm_build_container
+    if: github.repository_owner == 'ManageIQ'
     runs-on: ubuntu-latest
     steps:
     - name: Set up registry credentials
@@ -38,6 +39,7 @@ jobs:
         docker run docker.io/manageiq/rpm_build:latest build -v options:/root/OPTIONS --build-type nightly
   notify_builders:
     needs: build_rpms
+    if: github.repository_owner == 'ManageIQ'
     runs-on: ubuntu-latest
     steps:
     - name: Notify manageiq-pods on RPM build

--- a/.github/workflows/build_rpms.yaml
+++ b/.github/workflows/build_rpms.yaml
@@ -1,0 +1,31 @@
+name: Build RPMs
+
+on:
+  schedule:
+  - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  build_rpm_build_container:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up registry credentials
+      if: ${{ github.event_name != 'pull_request' }}
+      run: |
+        echo "REGISTRY_USERNAME=${{ secrets.REGISTRY_USERNAME }}" >> $GITHUB_ENV
+        echo "REGISTRY_PASSWORD=${{ secrets.REGISTRY_PASSWORD }}" >> $GITHUB_ENV
+    - name: Run container build script
+      run: bin/build_container_image
+  build_rpms:
+    needs: build_rpm_build_container
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up registry credentials
+      run: |
+        echo "REGISTRY_USERNAME=${{ secrets.REGISTRY_USERNAME }}" >> $GITHUB_ENV
+        echo "REGISTRY_PASSWORD=${{ secrets.REGISTRY_PASSWORD }}" >> $GITHUB_ENV
+    - name: Build and push RPMs
+      run: |
+        echo $REGISTRY_PASSWORD | docker login docker.io --password-stdin --username $REGISTRY_USERNAME
+        docker run docker.io/manageiq/rpm_build:latest build --build-type nightly

--- a/.github/workflows/build_rpms.yaml
+++ b/.github/workflows/build_rpms.yaml
@@ -28,7 +28,14 @@ jobs:
     - name: Build and push RPMs
       run: |
         echo $REGISTRY_PASSWORD | docker login docker.io --password-stdin --username $REGISTRY_USERNAME
-        docker run docker.io/manageiq/rpm_build:latest build --build-type nightly
+        mkdir options
+        echo "---" > options/options.yml
+        echo "rpm_repository:" >> options/options.yml
+        echo "  digitalocean_access_token: ${{ secrets.RPM_BUILD_DO_ACCESS_TOKEN }}" >> options/options.yml
+        echo "  s3_api:" >> options/options.yml
+        echo "    access_key: ${{ secrets.RPM_BUILD_S3_ACCESS_KEY " >> options/options.yml
+        echo "    secret_key: ${{ secrets.RPM_BUILD_S3_SECRET_KEY " >> options/options.yml
+        docker run docker.io/manageiq/rpm_build:latest build -v options:/root/OPTIONS --build-type nightly
   notify_builders:
     needs: build_rpms
     runs-on: ubuntu-latest


### PR DESCRIPTION
TODO:
- [x] Credentials for registry and RPM Repo
- [x] Trigger pods build
- ~~[ ] Tag builds~~ I think we'll handle tag builds manually on hte build machine as we have in the past?