### PR TITLE
Create a manageiq home directory

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -23,7 +23,9 @@ Requires: socat
 
 %pre core
 # ensure this user exists (build and upgrade)
-/usr/bin/id manageiq > /dev/null 2>&1 || /usr/sbin/useradd --system manageiq
+/usr/bin/id manageiq > /dev/null 2>&1 || /usr/sbin/useradd --system --create-home manageiq
+# create a manageiq home directory if it doesn't exist
+[[ ! -e /home/manageiq ]] && mkdir /home/manageiq && chown manageiq:manageiq /home/manageiq
 
 %posttrans core
 # 'bin' needs to be copied, not symlinked


### PR DESCRIPTION
Some ansible playbooks assume that /home/manageiq/.ansible exists and we were creating the manageiq user without a homedir.