### PR TITLE
Only ignore RPMs in the dockerignore, keep the directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 /BUILD/
 /OPTIONS/
-/rpm_cache/
+/rpm_cache/*.rpm
 Gemfile.lock


### PR DESCRIPTION
Example error:
```
/root/.local/share/gem/ruby/gems/aws-sdk-core-3.162.0/lib/seahorse/client/plugins/response_target.rb:67:in `initialize': No such file or directory @ rb_sysopen - /build_scripts/rpm_cache/kafka-3.2.0-1.el8.src.rpm (Errno::ENOENT)
```