### PR TITLE
Don't exit 1 since this may not be a real issue

### DIFF
--- a/lib/manageiq/rpm_build/rpm_repo.rb
+++ b/lib/manageiq/rpm_build/rpm_repo.rb
@@ -91,8 +91,7 @@ module ManageIQ
         retry_count ||= 0
         retry_count += 1
         if retry_count > 5
-          puts "Failed to flush CDN cache, exiting..."
-          exit 1
+          puts "Failed to flush CDN cache."
         else
           puts "Failed to flush CDN cache, retrying #{retry_count}..."
           retry


### PR DESCRIPTION
The exception may be raised because we're purging the cache for files that did and did not exist previously.