### PR TITLE
[WIP] Do not remove appliance COPY directory

### DIFF
--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -73,7 +73,6 @@ cd %{_builddir}
 %{__mkdir} -p %{buildroot}/etc/httpd/conf.d
 
 %{__cp} -a %{appliance_builddir}/* %{buildroot}%{appliance_root}
-%{__rm} -rf %{buildroot}%{appliance_root}/COPY
 
 ### from gemset
 %{__mkdir} -p %{buildroot}%{gemset_root}


### PR DESCRIPTION
The appliance COPY directory contains httpd configuration files that are required in the ManageIQ monolith container.

Related to:
- ManageIQ/manageiq#22186
- https://github.com/ManageIQ/manageiq/issues/22105