### PR TITLE
Upgrade to Kafka v3.3.1 and build for EL9

### DIFF
--- a/config/options.yml
+++ b/config/options.yml
@@ -40,7 +40,7 @@ rpm_repository:
       :targets:
         - el8
       :rpms:
-        :kafka: !ruby/regexp /.+-3\.2.+/
+        :kafka: !ruby/regexp /.+-3\.3.+/
         :manageiq: !ruby/regexp /.+-16\.\d\.\d-(alpha|beta|rc)?\d(\.\d)?\.el.+/
         :manageiq-release: !ruby/regexp /.+-16\.0.+/
         :python-bambou: !ruby/regexp /.+-3\.1\.1.+/

--- a/packages/kafka/README
+++ b/packages/kafka/README
@@ -1,0 +1,7 @@
+Build with:
+
+Fetch source files from https://rpm-manageiq-org.nyc3.digitaloceanspaces.com/index.html?prefix=sources_cache/kafka/ if needed.
+
+```bash
+mock --spec=./kafka.spec -r centos-stream-9-x86_64 --sources=./ --enable-network
+```

--- a/packages/kafka/kafka.spec
+++ b/packages/kafka/kafka.spec
@@ -1,6 +1,6 @@
 Name:             kafka
 Summary:          Apache Kafka is an open-source stream-processing software platform
-Version:          3.2.0
+Version:          3.3.1
 Release:          1%{?dist}
 License:          Apache (v2)
 Group:            Applications
@@ -108,6 +108,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Mon Oct 24 2022 "Brandon Dunne" <bdunne@redhat.com> - 3.3.1-1
+- Upgrade to v3.3.1
+
 * Fri Jul 08 2022 "Adam Grare" <adam@grare.com> - 3.2.0-1
 - Upgrade to v3.2.0
 

--- a/packages/kafka/kafka.spec
+++ b/packages/kafka/kafka.spec
@@ -6,6 +6,7 @@ License:          Apache (v2)
 Group:            Applications
 URL:              https://kafka.apache.org
 BuildRequires:    java-1.8.0-openjdk-devel >= 1.8
+BuildRequires:    systemd-rpm-macros
 Requires:         jre >= 1.8
 Requires(post):   systemd
 Requires(postun): systemd


### PR DESCRIPTION
kafka v3.3.1 RPMs for x86_64 EL8 &EL9 have been built and pushed to the kafka builds directory.
https://rpm.manageiq.org/index.html?prefix=builds/kafka/