### PR TITLE
Reduce the verbosity of the py3_shebang_fix

### DIFF
--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -49,7 +49,7 @@ umask 0002
 # buildsubdir is set to the last extracted archive, reset
 cd %{_builddir}
 
-%py3_shebang_fix %{gemset_builddir}
+%py3_shebang_fix %{gemset_builddir} 2>&1 | grep -v "^recursedown" | grep -v "no change"
 
 %build
 cd %{_builddir}


### PR DESCRIPTION
Before, we get hundreds of lines starting with `recursedown`, and files examined with `no change`. After, removing these gets us only to the files that are actually changed, which at the time of this commit is 3 files.

@bdunne Please review.