### PR TITLE
Fix missing packages in manageiq-ansible-venv

### DIFF
--- a/lib/manageiq/rpm_build/generate_ansible_venv.rb
+++ b/lib/manageiq/rpm_build/generate_ansible_venv.rb
@@ -46,7 +46,10 @@ module ManageIQ
       def install_python_system_packages
         where_am_i
 
-        shell_cmd("#{pip_versioned} install virtualenv psutil==5.6.6", "PYTHONDONTWRITEBYTECODE" => "1")
+        # NOTE: This is intentionally _not_ versioned so as to install in the system python path.
+        shell_cmd("pip3 install --no-compile psutil==5.6.6")
+
+        shell_cmd("#{pip_versioned} install --no-compile virtualenv")
       end
 
       def create_venv
@@ -82,7 +85,14 @@ module ManageIQ
         where_am_i
 
         FileUtils.rm_rf(venv_dir)
+
+        # Copy the venv dir
         FileUtils.mv(@venv_build_dir, venv_dir)
+
+        # Copy python 3.6 site-packages
+        site_packages_dir = venv_dir.join("site-packages")
+        FileUtils.mkdir_p(site_packages_dir)
+        FileUtils.cp_r(Dir.glob("/usr/local/lib64/python3.6/site-packages/psutil*"), site_packages_dir)
       end
 
       def pip_versioned

--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -6,6 +6,7 @@
 %global app_root /var/www/miq/vmdb
 %global org_root /opt/%{org_name}
 %global ansible_venv_root /var/lib/manageiq
+%global ansible_venv_site_packages /usr/local/lib64/python3.6/site-packages
 %global appliance_root %{org_root}/%{name}-appliance
 %global gemset_root %{org_root}/%{name}-gemset
 %global manifest_root %{org_root}/manifest
@@ -135,13 +136,17 @@ done
 # Install ansible-venv #
 ########################
 %{__mkdir} -p %{buildroot}%{ansible_venv_root}
-%{__cp} -r %{ansible_venv_builddir}/* %{buildroot}%{ansible_venv_root}
+%{__cp} -a %{ansible_venv_builddir}/venv %{buildroot}%{ansible_venv_root}
 
 ln -s /usr/bin/python3.8 %{buildroot}%{ansible_venv_root}/venv/bin/python3.8
 ln -s ./python3.8 %{buildroot}%{ansible_venv_root}/venv/bin/python3
 ln -s ./python3 %{buildroot}%{ansible_venv_root}/venv/bin/python
 
-%{__mv} %{buildroot}%{ansible_venv_root}/ansible_venv_manifest.csv %{buildroot}%{manifest_root}
+# Copy site-packages
+%{__mkdir} -p %{buildroot}%{ansible_venv_site_packages}
+%{__cp} -a %{ansible_venv_builddir}/site-packages/* %{buildroot}%{ansible_venv_site_packages}
+
+%{__cp} %{ansible_venv_builddir}/ansible_venv_manifest.csv %{buildroot}%{manifest_root}
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/rpm_spec/subpackages/manageiq-ansible-venv
+++ b/rpm_spec/subpackages/manageiq-ansible-venv
@@ -13,4 +13,5 @@ Requires: python38
 %files ansible-venv
 %defattr(-,root,root,-)
 %{ansible_venv_root}
+%{ansible_venv_site_packages}/*
 %{manifest_root}/ansible_venv_manifest.csv


### PR DESCRIPTION
Followup fixes after https://github.com/ManageIQ/manageiq-appliance-build/issues/423

This fixes issues where psutil was missing from the system site-packages.  After this PR, I can successfully run playbooks (tested with the hello world and vsphere playbooks)

@bdunne or @jrafanie Please review.