### PR TITLE
Force installation and usage of postgresql 13 for appliance rpm

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -6,7 +6,7 @@ Requires: %{name}-ui = %{version}-%{release}
 Requires: %{name}-core-services = %{version}-%{release}
 Requires: %{name}-gemset-services = %{version}-%{release}
 
-Requires: postgresql-server
+Requires: postgresql-server >= 13
 Requires: repmgr13 >= 5.2.1
 
 Requires: lvm2

--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -1,7 +1,7 @@
 %package core
 Summary:  %{product_summary} Core
 
-Requires: ruby
+Requires: ruby >= 3
 # Include weak dependencies of Ruby that we actually need
 Requires: ruby-default-gems
 Requires: rubygem-bigdecimal


### PR DESCRIPTION
Previously, we had to manually upgrade postgresql and ruby by using:

```
dnf -y upgrade --refresh *.x86_64.rpm ruby* postgresql*
```

With this change, manageiq-core requires ruby 3 and manageiq-appliance requires postgresql 13 so we can just update our manageiq rpms and postgresql 13 will be installed since it's not on existing setups:

```
dnf -y upgrade --refresh *.x86_64.rpm
```

![image](https://user-images.githubusercontent.com/19339/200954244-3f4a7368-9102-4ad0-8864-23dafa48730d.png)
