### PR TITLE
Lock down license_finder to 7.0.1

### DIFF
--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -109,7 +109,7 @@ module ManageIQ
 
         FileUtils.mkdir_p(manifest_dir)
 
-        shell_cmd("gem install license_finder")
+        shell_cmd("gem install license_finder -v '~> 7.0.1'")
         generate_gem_manifest
         generate_npm_manifest
       end


### PR DESCRIPTION
7.1.0 was released yesterday and we are seeing the following error: 
```
LicenseFinder::NPM: is active
LicenseFinder::Yarn: is active
/root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/lib/license_finder/package_managers/yarn.rb:98:in `block in get_yarn_packages': undefined method `each' for nil:NilClass (NoMethodError)
	from /root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/lib/license_finder/package_managers/yarn.rb:94:in `each'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/lib/license_finder/package_managers/yarn.rb:94:in `get_yarn_packages'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/lib/license_finder/package_managers/yarn.rb:34:in `current_packages'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/lib/license_finder/package_manager.rb:105:in `current_packages_with_relations'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/lib/license_finder/scanner.rb:42:in `each'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/lib/license_finder/scanner.rb:42:in `flat_map'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/lib/license_finder/scanner.rb:42:in `active_packages'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/lib/license_finder/core.rb:84:in `current_packages'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/lib/license_finder/core.rb:79:in `decision_applier'
	from /usr/share/ruby/forwardable.rb:232:in `acknowledged'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:51:in `block in aggregate_packages'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:49:in `each'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:49:in `flat_map'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:49:in `aggregate_packages'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:11:in `dependencies'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/lib/license_finder/cli/main.rb:161:in `report'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/thor-1.2.1/lib/thor/base.rb:485:in `start'
	from /root/BUILD/manageiq-gemset-16.0.0/gems/license_finder-7.1.0/bin/license_finder:6:in `<top (required)>'
	from /root/BUILD/manageiq-gemset-16.0.0/bin/license_finder:25:in `load'
	from /root/BUILD/manageiq-gemset-16.0.0/bin/license_finder:25:in `<main>'
Error: Process completed with exit code 1.
```