### PR TITLE
[WIP] Bump ansible-runner to use python3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ RUN ARCH=$(uname -m) && \
       libxslt-devel \
       make \
       openssl-devel \
-      python38-devel \
-      python38-pip \
+      python39-devel \
+      python39-pip \
       rpm-build && \
     dnf -y update libarchive && \
     if [ ${ARCH} = "s390x" ] || [ ${ARCH} = "ppc64le" ] ; then dnf -y install python2 ; fi && \

--- a/config/exclude_ansible-venv
+++ b/config/exclude_ansible-venv
@@ -1,3 +1,3 @@
 venv/bin/python
 venv/bin/python3
-venv/bin/python3.8
+venv/bin/python3.9

--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -6,7 +6,7 @@
 %global app_root /var/www/miq/vmdb
 %global org_root /opt/%{org_name}
 %global ansible_venv_root /var/lib/manageiq
-%global ansible_venv_site_packages /usr/local/lib/python3.8/site-packages
+%global ansible_venv_site_packages /usr/local/lib/python3.9/site-packages
 %global appliance_root %{org_root}/%{name}-appliance
 %global gemset_root %{org_root}/%{name}-gemset
 %global manifest_root %{org_root}/manifest
@@ -138,8 +138,8 @@ done
 %{__mkdir} -p %{buildroot}%{ansible_venv_root}
 %{__cp} -a %{ansible_venv_builddir}/venv %{buildroot}%{ansible_venv_root}
 
-ln -s /usr/bin/python3.8 %{buildroot}%{ansible_venv_root}/venv/bin/python3.8
-ln -s ./python3.8 %{buildroot}%{ansible_venv_root}/venv/bin/python3
+ln -s /usr/bin/python3.9 %{buildroot}%{ansible_venv_root}/venv/bin/python3.9
+ln -s ./python3.9 %{buildroot}%{ansible_venv_root}/venv/bin/python3
 ln -s ./python3 %{buildroot}%{ansible_venv_root}/venv/bin/python
 
 # Copy site-packages and ansible-runner bin file

--- a/rpm_spec/subpackages/manageiq-ansible-venv
+++ b/rpm_spec/subpackages/manageiq-ansible-venv
@@ -4,7 +4,7 @@ Summary: %{product_summary} Ansible Runner Virtual Environment
 %global __requires_exclude ^\/var\/lib\/manageiq\/venv\/bin\/python
 
 Requires: ansible
-Requires: python38
+Requires: python39
 
 %description ansible-venv
 %{product_summary} Ansible Runner Virtual Environment


### PR DESCRIPTION
EPEL no longer ships ansible 5 / ansible-core 2.12, which used python 3.8, and instead ships ansible 6 / ansible-core 2.13, which uses python 3.9 instead. As such, our pre-installed runner is expecting 3.8 and installs there, but breaks when used in a more recent build.

@bdunne Please review.  master, oparin, najdorf, and morphy are all busted because of this.  The backport for najdorf and morphy will have to be different, but right now I'm focused on oparin.

WIP because I need to still fully test and verify.