### PR TITLE
Lockdown ansible to 5.4.0-3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ RUN ARCH=$(uname -m) && \
       qpid-proton-c-devel \
       ruby-devel \
       wget \
-      # For seeding ansible runner / ansible-galaxy
-      ansible \
+      # For seeding ansible runner with ansible-galaxy, and for ansible-venv
+      ansible-5.4.0-3.el8 \
       # For ansible-venv
       gcc \
       krb5-devel \

--- a/rpm_spec/subpackages/manageiq-ansible-venv
+++ b/rpm_spec/subpackages/manageiq-ansible-venv
@@ -3,7 +3,7 @@ Summary: %{product_summary} Ansible Runner Virtual Environment
 
 %global __requires_exclude ^\/var\/lib\/manageiq\/venv\/bin\/python
 
-Requires: ansible
+Requires: ansible >= 5, ansible < 6
 Requires: python38
 
 %description ansible-venv


### PR DESCRIPTION
epel no longer ships ansible 5, which used python 3.8, and instead ships ansible 6 which uses python 3.9 instead.  As such, our preinstalled runner is expecting packages in the 3.9 site-packages but we install into 3.8 instead.

This commit locks down ansible to 5.4.0-3 until we can fully verify ansible 6. ansible 5.4.0-3 is being built by us in #347 (03bf6277).

@bdunne Please review.  This is an alternative to #346 


WIP until I can verify a build with it