### PR TITLE
list all vmdb directories in the gem

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -55,12 +55,38 @@ done
 
 %files core
 %defattr(-,root,root,-)
-%{app_root}
+%{app_root}/AUTHORS
+%{app_root}/CHANGELOG.md
+%{app_root}/CONTRIBUTING.md
+%{app_root}/Dockerfile
+%{app_root}/Gemfile
+%{app_root}/LICENSE.txt
+%{app_root}/NOTICE.txt
+%{app_root}/Procfile.example
+%{app_root}/README.md
+%{app_root}/Rakefile
+%{app_root}/VERSION
+%{app_root}/app
+%{app_root}/bin
+%{app_root}/bundler.d
 %attr(-,manageiq,manageiq) %{app_root}/certs
 %attr(-,manageiq,manageiq) %{app_root}/config
-%attr(-,manageiq,manageiq) %{app_root}/log
-%attr(-,manageiq,manageiq) %{app_root}/tmp
+%{app_root}/config.ru
+%{app_root}/container-assets
+%{app_root}/content
 %attr(-,manageiq,manageiq) %{app_root}/data
+%{app_root}/db
+%{app_root}/lib
+%{app_root}/locale
+%attr(-,manageiq,manageiq) %{app_root}/log
+%{app_root}/product
+%{app_root}/public
+%{app_root}/script
+%{app_root}/spec
+%{app_root}/systemd
+%attr(-,manageiq,manageiq) %{app_root}/tmp
+%{app_root}/tools
+
 %config(noreplace) %{app_root}/config/cable.yml
 %exclude %{app_root}/public/pictures
 %exclude %{app_root}/public/assets


### PR DESCRIPTION
## Overview

Fixes #332

The goal is to remove a warning:

```
warning: File listed twice: /var/www/miq/vmdb/certs
(a few hundred files do this)
```

## Before

```
%defattr(-,root,root,-)
%{app_root}
%attr(-,manageiq,manageiq) %{app_root}/certs
```

We stated that we included all files recursively under app_root (/var/www/miq/vmdb).
Then we stated a few directories (with different privileges) under app_root.
So we ended up with duplicates.


## Why?

Most app_root subdirectories are owned by root, which is the default, so using the app_root line works.

There are a few config directories that need to be editable and owned by the end user. That is why they are listed with the `%attr()` syntax.

## After

We explicitly listed each folder in the rails root.

I would have liked to keep on using the app_root rule so any additional files would be auto added.

This is tricky because we tend to not debug the directory listing of the `rpm` So there is a good chance that we will add a directory to app_root (vmdb / manageiq-core root) and will think it is all set but will fail on the appliance.
