### PR TITLE
Update nokogiri to 1.13.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,6 @@ gem 'rake',           ">=12.3.3"
 gem 'term-ansicolor'
 
 group :test do
-  gem "nokogiri", "~> 1.13", ">= 1.13.6" # indirect dependency of rspec-rails; added to fix CVEs
+  gem "nokogiri", "~> 1.13", ">= 1.13.10" # indirect dependency of rspec-rails; added to fix CVEs
   gem "rspec-rails", "~>5.1"
 end


### PR DESCRIPTION
I'm not sure why Mend is saying that rails-html-sanitizer is wrong, because locally it resolves correctly.  Even so, we can update the minimum for nokogiri, and it's possible this will trigger a re-run.