### PR TITLE
Fix issue where the wrong image tag was used for building RPMs

### DIFF
--- a/.github/workflows/build_rpms.yaml
+++ b/.github/workflows/build_rpms.yaml
@@ -15,7 +15,7 @@ jobs:
       run: |
         echo "REGISTRY_USERNAME=${{ secrets.DOCKER_REGISTRY_USERNAME }}" >> $GITHUB_ENV
         echo "REGISTRY_PASSWORD=${{ secrets.DOCKER_REGISTRY_PASSWORD }}" >> $GITHUB_ENV
-    - name: Run container build script
+    - name: Build and push RPM build image
       run: bin/build_container_image
   build_rpms:
     needs: build_rpm_build_container
@@ -26,17 +26,17 @@ jobs:
       run: |
         echo "REGISTRY_USERNAME=${{ secrets.DOCKER_REGISTRY_USERNAME }}" >> $GITHUB_ENV
         echo "REGISTRY_PASSWORD=${{ secrets.DOCKER_REGISTRY_PASSWORD }}" >> $GITHUB_ENV
-    - name: Build and push RPMs
+    - name: Prepare options file
       run: |
-        echo $REGISTRY_PASSWORD | docker login docker.io --password-stdin --username $REGISTRY_USERNAME
-        mkdir /tmp/options
+        mkdir -p /tmp/options
         echo "---" > /tmp/options/options.yml
         echo "rpm_repository:" >> /tmp/options/options.yml
         echo "  digitalocean_access_token: ${{ secrets.RPM_BUILD_DO_ACCESS_TOKEN }}" >> /tmp/options/options.yml
         echo "  s3_api:" >> /tmp/options/options.yml
         echo "    access_key: ${{ secrets.RPM_BUILD_S3_ACCESS_KEY }}" >> /tmp/options/options.yml
         echo "    secret_key: ${{ secrets.RPM_BUILD_S3_SECRET_KEY }}" >> /tmp/options/options.yml
-        docker run -v /tmp/options:/root/OPTIONS:z docker.io/manageiq/rpm_build:latest build --build-type nightly --git-ref ${{ github.ref_name }} --update-rpm-repo
+    - name: Build and push RPMs
+      run: run_container_image
   notify_builders:
     needs: build_rpms
     if: github.repository_owner == 'ManageIQ'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,5 +33,5 @@ jobs:
       run: |
         echo "REGISTRY_USERNAME=${{ secrets.DOCKER_REGISTRY_USERNAME }}" >> $GITHUB_ENV
         echo "REGISTRY_PASSWORD=${{ secrets.DOCKER_REGISTRY_PASSWORD }}" >> $GITHUB_ENV
-    - name: Run container build script
+    - name: Build and push RPM build image
       run: bin/build_container_image

--- a/bin/run_container_image
+++ b/bin/run_container_image
@@ -11,12 +11,8 @@ IMAGE_NAME=${IMAGE_NAME:-"$DEFAULT_IMAGE_NAME"}
 
 set -e
 
-docker build . -t $IMAGE_NAME
-
-[[ -z "$REGISTRY_USERNAME" ]] && exit 0
-
 echo "$REGISTRY_PASSWORD" | docker login $REGISTRY -u $REGISTRY_USERNAME --password-stdin
 
-docker push $IMAGE_NAME
+docker run -v /tmp/options:/root/OPTIONS:z $IMAGE_NAME build --build-type nightly --git-ref $GITHUB_REF_NAME --update-rpm-repo
 
 set +e


### PR DESCRIPTION
This commit also moves the execution into bin/run_container_image in order to copy the logic that sets up the ENV vars that define the image tag.

@bdunne Please review.