### PR TITLE
Don't push the built image during CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,10 +28,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up registry credentials
-      if: "${{ github.event_name != 'pull_request' }}"
-      run: |
-        echo "REGISTRY_USERNAME=${{ secrets.DOCKER_REGISTRY_USERNAME }}" >> $GITHUB_ENV
-        echo "REGISTRY_PASSWORD=${{ secrets.DOCKER_REGISTRY_PASSWORD }}" >> $GITHUB_ENV
-    - name: Build and push RPM build image
+    - name: Build RPM build image
       run: bin/build_container_image


### PR DESCRIPTION
In CI we only care that things build correctly. Additionally, the new build_rpms workflow builds the latest image anyway, so the CI version is never really used.

See https://github.com/ManageIQ/manageiq-rpm_build/pull/363#discussion_r1056686577

@bdunne Please review.