### PR TITLE
Lock the petrosian release branch to test with ruby 3.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.7'
         - '3.0'
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Lock the petrosian release branch to test with ruby 3.0