### PR TITLE
If the directory already exists, preinstall script fails

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -24,7 +24,7 @@ Requires: socat
 # ensure this user exists (build and upgrade)
 /usr/bin/id manageiq > /dev/null 2>&1 || /usr/sbin/useradd --system --create-home manageiq
 # create a manageiq home directory if it doesn't exist
-[[ ! -e /home/manageiq ]] && mkdir /home/manageiq && chown manageiq:manageiq /home/manageiq
+mkdir -p /home/manageiq && chown manageiq:manageiq /home/manageiq
 
 %posttrans core
 # 'bin' needs to be copied, not symlinked


### PR DESCRIPTION
Introduced in #307 
```bash
[root@2deb833254d8 /]# [[ ! -e /home/manageiq ]] && mkdir -p /home/manageiq && chown manageiq:manageiq /home/manageiq [root@2deb833254d8 /]# echo $?
1
[root@2deb833254d8 /]# mkdir -p /home/manageiq && chown manageiq:manageiq /home/manageiq [root@2deb833254d8 /]# echo $?
0
```

Error:
```bash
Running transaction
  Preparing        :                                                                                                                                                                                                                      1/1
  Running scriptlet: manageiq-core-17.0.0-20230327001608.el8.x86_64                                                                                                                                                                       1/1
error: %prein(manageiq-core-17.0.0-20230327001608.el8.x86_64) scriptlet failed, exit status 1

Error in PREIN scriptlet in rpm package manageiq-core
  Verifying        : manageiq-core-17.0.0-20230327001608.el8.x86_64                                                                                                                                                                       1/1

Failed:
  manageiq-core-17.0.0-20230327001608.el8.x86_64

Error: Transaction failed
```