### PR TITLE
This doesn't appear to be an option after npm upgrade

### DIFF
--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -79,10 +79,6 @@ module ManageIQ
             shell_cmd("#{SCRIPT_DIR.join("npm_registry/yarn_registry_setup.sh")} #{OPTIONS.npm_registry}")
           end
 
-          # HACK: Use Python 2.7 for ppc64 and s390x
-          # TODO: Find out why...
-          shell_cmd("npm config --global set python /usr/bin/python2.7") if Gem::Platform.local.cpu != "x86_64"
-
           shell_cmd("rake update:ui")
 
           # Add .bundle, bin, manifest and Gemfile.lock to the gemset


### PR DESCRIPTION
```
 ---> npm config --global set python /usr/bin/python2.7[0m[0m
npm ERR! `python` is not a valid npm option

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2023-04-27T14_17_44_165Z-debug-0.log
```