### PR TITLE
Revert "Merge pull request #275 from Minal-Mahor/s390x-changes"

### DIFF
--- a/lib/manageiq/rpm_build/generate_core.rb
+++ b/lib/manageiq/rpm_build/generate_core.rb
@@ -56,7 +56,6 @@ module ManageIQ
         symlink_plugin_paths("manageiq-ui-service", ui_service_dir)
 
         Dir.chdir(ui_service_dir) do
-          shell_cmd("yarn set version 1.22.18") if RUBY_PLATFORM.include?("s390x")
           shell_cmd("yarn install")
           shell_cmd("yarn run available-languages")
           shell_cmd("yarn run build")


### PR DESCRIPTION
This reverts commit f95abd0882bfc1670473dd2d40cde4f9d35c20ee, reversing changes made to 88e993d32e6103b655ba1b1a858c2246373bb766.

On petrosian, s390x rpm build fails with:
```
 ---> yarn set version 1.22.18[0m[0m
➤ YN0000: Retrieving https://github.com/yarnpkg/yarn/releases/download/v1.22.18/yarn-1.22.18.js
➤ YN0000: Saving the new release in .yarn/releases/yarn-1.22.18.cjs
➤ YN0000: Done in 1s 201ms
[1m[33m
 ---> yarn install[0m[0m
yarn install v1.22.18
info If you think this is a bug, please open a bug report with the information provided in "/root/BUILD/manageiq-ui-service/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
error An unexpected error occurred: "Unknown token: { line: 3, col: 2, type: 'INVALID', value: undefined } 3:2 in /root/BUILD/manageiq-ui-service/yarn.lock".
Build step 'Execute shell' marked build as failure
```