### PR TITLE
Revert "Merge pull request #392 from bdunne/revert_275"

### DIFF
--- a/lib/manageiq/rpm_build/generate_core.rb
+++ b/lib/manageiq/rpm_build/generate_core.rb
@@ -56,6 +56,7 @@ module ManageIQ
         symlink_plugin_paths("manageiq-ui-service", ui_service_dir)
 
         Dir.chdir(ui_service_dir) do
+          shell_cmd("yarn set version 1.22.18") if RUBY_PLATFORM.include?("s390x")
           shell_cmd("yarn install")
           shell_cmd("yarn run available-languages")
           shell_cmd("yarn run build")


### PR DESCRIPTION
This sets the yarn version back to 1.22.18.  On the newer versions, we get stuck during `yarn install` on manageiq-ui-service, but only on the s390x platform.

Example:
```
[root@c18d5e2335b7 manageiq-ui-service]# yarn install --immutable --inline-builds
➤ YN0000: ┌ Resolution step
➤ YN0002: │ angular-bootstrap-switch@npm:0.5.2 doesn't provide @popperjs/core (p47073), requested by bootstrap
➤ YN0002: │ bootstrap-combobox@npm:1.0.2 doesn't provide @popperjs/core (p04235), requested by bootstrap
➤ YN0002: │ manageiq-ui-service@workspace:. doesn't provide bootstrap (p946e6), requested by bootstrap-switch
➤ YN0002: │ manageiq-ui-service@workspace:. doesn't provide postcss (p559f3), requested by postcss-loader
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
➤ YN0000: └ Completed in 0s 449ms
➤ YN0000: ┌ Fetch step
➤ YN0013: │ @babel/helper-validator-option@npm:7.21.0 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ @babel/helper-wrap-function@npm:7.20.5 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ @babel/helpers@npm:7.21.0 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ @babel/parser@npm:7.21.2 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ @babel/highlight@npm:7.18.6 can't be found in the cache and will be fetched from the remote registry
➤ YN0000: ⠏ --------------------------------------------------------------------------------
```