### PR TITLE
[MORPHY] Switch to IBM Cloud as the upload destination

### DIFF
--- a/config/options.yml
+++ b/config/options.yml
@@ -28,7 +28,7 @@ rpm_repository:
     access_key:
     secret_key:
     bucket: rpm-manageiq-org
-    endpoint: nyc3.digitaloceanspaces.com
+    endpoint: s3.us-east.cloud-object-storage.appdomain.cloud
   :arches:
   - src
   - noarch

--- a/lib/manageiq/rpm_build/rpm_repo.rb
+++ b/lib/manageiq/rpm_build/rpm_repo.rb
@@ -74,28 +74,6 @@ module ManageIQ
               client.delete_object(:bucket => OPTIONS.rpm_repository.s3_api.bucket, :key => object.key)
             end
           end
-
-          # Bust the cache for updated files
-          flush_cdn_cache(uploaded_files) if OPTIONS.rpm_repository.digitalocean_access_token
-        end
-      end
-
-      private
-
-      def flush_cdn_cache(uploaded_files)
-        puts "Purging the cache for files that were uploaded"
-        digitalocean_client = DropletKit::Client.new(:access_token => OPTIONS.rpm_repository.digitalocean_access_token)
-        cdn_id = digitalocean_client.cdns.all.detect { |i| i.origin == "#{OPTIONS.rpm_repository.s3_api.bucket}.#{OPTIONS.rpm_repository.s3_api.endpoint}" }.id
-        digitalocean_client.cdns.flush_cache(:id => cdn_id, :files => uploaded_files)
-      rescue DropletKit::Error
-        retry_count ||= 0
-        retry_count += 1
-        if retry_count > 5
-          puts "Failed to flush CDN cache, exiting..."
-          exit 1
-        else
-          puts "Failed to flush CDN cache, retrying #{retry_count}..."
-          retry
         end
       end
     end

--- a/lib/manageiq/rpm_build/s3_common.rb
+++ b/lib/manageiq/rpm_build/s3_common.rb
@@ -6,12 +6,11 @@ module ManageIQ
       def client
         @client ||= begin
           require 'aws-sdk-s3'
-          Aws::S3::Client.new(
-            :access_key_id     => OPTIONS.rpm_repository.s3_api.access_key,
-            :secret_access_key => OPTIONS.rpm_repository.s3_api.secret_key,
-            :region            => 'us-east-1',
-            :endpoint          => "https://#{OPTIONS.rpm_repository.s3_api.endpoint}"
-          )
+          Aws::S3::Resource.new(
+            :credentials => Aws::Credentials.new(OPTIONS.rpm_repository.s3_api.access_key, OPTIONS.rpm_repository.s3_api.secret_key),
+            :region      => 'us-east',
+            :endpoint    => "https://#{OPTIONS.rpm_repository.s3_api.endpoint}"
+          ).client
         end
       end
 


### PR DESCRIPTION
Backport of #387 
Fixed conflict in lib/manageiq/rpm_build/rpm_repo.rb

Switch to IBM Cloud as the upload destination

(cherry picked from commit b3cf81e06c24440ae61dda3f789769c75854c904)