### PR TITLE
Add Podman as dependency for manageiq-appliance

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -13,6 +13,7 @@ Requires: lvm2
 Requires: memcached
 
 Requires: kafka
+Requires: podman
 
 # NTP
 Requires: chrony


### PR DESCRIPTION
Podman will be used to run containers for workflows and potentially
workers in the future.

![Screenshot from 2023-06-29 12-59-43](https://github.com/ManageIQ/manageiq-rpm_build/assets/12851112/8370f2a7-5471-495d-bf6e-dbcf3f710b4b)


https://github.com/ManageIQ/manageiq/issues/22311