### PR TITLE
Remove references to yarn 1.22.18

### DIFF
--- a/lib/manageiq/rpm_build/generate_core.rb
+++ b/lib/manageiq/rpm_build/generate_core.rb
@@ -61,7 +61,10 @@ module ManageIQ
           shell_cmd("yarn run available-languages")
           shell_cmd("yarn run build")
           shell_cmd("git clean -xdf")  # cleanup temp files
-          shell_cmd("yarn set version 1.22.18") if RUBY_PLATFORM.include?("s390x")
+          if RUBY_PLATFORM.include?("s390x")
+            shell_cmd("git checkout .yarn*")
+            shell_cmd("yarn set version 1.22.18")
+          end
         end
       end
 


### PR DESCRIPTION
- Reset .yarnrc to remove reference to remove reference to 1.22.18 which was removed by git clean above
- Restore yarn 3.5.0 so that we can install 1.22.18 again

Details after yarn install on s390x:
```
[root@0c770d65ccb1 manageiq-ui-service]# git status On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	deleted:    .yarn/releases/yarn-3.5.0.cjs
	modified:   .yarnrc.yml
	modified:   package.json
	modified:   yarn.lock

no changes added to commit (use "git add" and/or "git commit -a") [root@0c770d65ccb1 manageiq-ui-service]# git checkout .yarn* Updated 2 paths from the index
[root@0c770d65ccb1 manageiq-ui-service]# yarn set version 1.22.18 ➤ YN0000: Retrieving https://github.com/yarnpkg/yarn/releases/download/v1.22.18/yarn-1.22.18.js ➤ YN0000: Saving the new release in .yarn/releases/yarn-1.22.18.cjs ➤ YN0000: Done in 1s 103ms
```