### PR TITLE
declare rpm dependencies for creating user

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -16,6 +16,8 @@ Requires: net-snmp
 Requires: net-snmp-libs
 Requires: net-snmp-utils
 Requires: socat
+Requires: core-utils     # rpm %pre calls uses id
+Requires: shadow-utils   # rpm %pre calls uses useradd
 
 %description core
 %{product_summary} Core


### PR DESCRIPTION
We create a manageiq user to properly setup
permissions as the manageiq (non-root) user

couldn't reopen https://github.com/ManageIQ/manageiq-rpm_build/pull/221
Created a new one