### PR TITLE
Registry is set differently for diffrent yarn versions

### DIFF
--- a/scripts/npm_registry/yarn_registry_cleanup.sh
+++ b/scripts/npm_registry/yarn_registry_cleanup.sh
@@ -2,8 +2,12 @@
 
 NPM_REGISTRY_OVERRIDE="$1"
 
-yarn config delete npmRegistryServer
-yarn config delete enableStrictSsl
+if [[ $(uname -m) == "s390x" ]]; then
+  # For yarn v1
+  yarn config delete registry
+else
+  yarn config delete npmRegistryServer
+fi
 
 # Replace registry in yarn.lock
 default_yarn_registry=`yarn config get npmRegistryServer`

--- a/scripts/npm_registry/yarn_registry_setup.sh
+++ b/scripts/npm_registry/yarn_registry_setup.sh
@@ -2,8 +2,12 @@
 
 NPM_REGISTRY_OVERRIDE="$1"
 
-yarn config set npmRegistryServer ${NPM_REGISTRY_OVERRIDE}
-yarn config set enableStrictSsl false
+if [[ $(uname -m) == "s390x" ]]; then
+  # For yarn v1
+  yarn config set registry ${NPM_REGISTRY_OVERRIDE}
+else
+  yarn config set npmRegistryServer ${NPM_REGISTRY_OVERRIDE}
+fi
 
 # Replace registry in existing yarn.lock
 ui_plugin_repos=`rake update:print_engines | grep path: | cut -d: -f2`


### PR DESCRIPTION
We're still on yarn v1 on s390x

Also, I don't know why we were disabling strict ssl, but we probably shouldn't do that.