### PR TITLE
Fix RPM spec require parsing issue

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -16,8 +16,12 @@ Requires: net-snmp
 Requires: net-snmp-libs
 Requires: net-snmp-utils
 Requires: socat
-Requires: core-utils     # rpm %pre calls uses id
-Requires: shadow-utils   # rpm %pre calls uses useradd
+
+# rpm %pre uses id
+Requires: core-utils
+
+# rpm %pre uses useradd
+Requires: shadow-utils
 
 %description core
 %{product_summary} Core


### PR DESCRIPTION
Introduced in #406 
```
 ---> rpmbuild -ba --define '_sourcedir /root/BUILD/rpm_spec' --define '_srcrpmdir /root/BUILD/rpms/x86_64' --define '_rpmdir /root/BUILD/rpms' manageiq.spec
error: line 307: Dependency tokens must begin with alpha-numeric, '_' or '/': Requires: core-utils     # rpm %pre calls uses id
```