### PR TITLE
core-utils is coreutils on appliances and coreutils-single on containers

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -17,8 +17,8 @@ Requires: net-snmp-libs
 Requires: net-snmp-utils
 Requires: socat
 
-# rpm %pre uses id
-Requires: core-utils
+# rpm %pre uses id (appliance or containers)
+Requires: (coreutils or coreutils-single)
 
 # rpm %pre uses useradd
 Requires: shadow-utils


### PR DESCRIPTION
The two packages conflict with each other, so we have to specify an OR on the requires

Followup to: https://github.com/ManageIQ/manageiq-rpm_build/pull/406