### PR TITLE
Add subuid/subgid for the manageiq user

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -61,6 +61,11 @@ Requires: cockpit-ws
 %description appliance
 %{product_summary} Appliance
 
+%pre appliance
+# Add sub uids/gids for running non-privileged containers
+grep manageiq /etc/subuid >/dev/null 2>&1 || /usr/sbin/usermod --add-subuids 100000-165535 manageiq
+grep manageiq /etc/subgid >/dev/null 2>&1 || /usr/sbin/usermod --add-subgids 100000-165535 manageiq
+
 %posttrans appliance
 %{_bindir}/systemctl try-restart evmserverd.service
 


### PR DESCRIPTION
Allow running non-root containers by setting subuid/gid maps for the manageiq user.  This resolves the "chown" issue when pulling images as the manageiq user as well as fixing the warnings present when running with the missing uid maps.

https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md#etcsubuid-and-etcsubgid-configuration