### PR TITLE
Revert "Lock down to UBI 8.8-1032"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.8-1032
+FROM registry.access.redhat.com/ubi8/ubi
 
 ENV TERM=xterm \
     APPLIANCE=true \


### PR DESCRIPTION
This reverts commit 992f1ab536c70cebadb19d72523f0685e8163b50.

A new UBI8 image has been released. The yum repos are available on ppc64le now.