### PR TITLE
Fix missing git_ref default value

### DIFF
--- a/bin/build.rb
+++ b/bin/build.rb
@@ -7,7 +7,7 @@ require 'optimist'
 
 opts = Optimist.options do
   opt :build_type,      "nightly or release", :type => :string, :default => "nightly"
-  opt :git_ref,         "Git ref to use (default: git_ref specified in options.yml)", :type => :string
+  opt :git_ref,         "Git ref to use (default: git_ref specified in options.yml)", :type => :string, :default => ManageIQ::RPMBuild::OPTIONS.repos.ref
   opt :update_rpm_repo, "Publish the resulting RPMs to the public repository?"
 end
 Optimist.die "build type must be either nightly or release" unless %w[nightly release].include?(opts[:build_type])


### PR DESCRIPTION
Using `--build-type release` depends on having a git_ref, the documented default was not implemented though.  Error:
```
/build_scripts/lib/manageiq/rpm_build/build_copr.rb:68:in `spec_release': undefined method `empty?' for nil:NilClass (NoMethodError)
	from /build_scripts/lib/manageiq/rpm_build/build_copr.rb:62:in `update_spec'
	from /build_scripts/lib/manageiq/rpm_build/build_copr.rb:48:in `generate_spec_from_template'
	from /build_scripts/lib/manageiq/rpm_build/build_copr.rb:23:in `block in generate_rpm'
	from /build_scripts/lib/manageiq/rpm_build/build_copr.rb:22:in `chdir'
	from /build_scripts/lib/manageiq/rpm_build/build_copr.rb:22:in `generate_rpm'
	from bin/build.rb:51:in `<main>'
```