### PR TITLE
Disable rsyslog duplication of systemd-journal

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -100,6 +100,9 @@ fi
 # Disable rsyslog duplicating systemd-journal output
 # This will comment out the multi-line module load from /etc/rsyslog.conf
 sed -i '/module(load="imjournal"/, /StateFile="imjournal.state")/ s|^|#|' %{_sysconfdir}/rsyslog.conf
+if systemctl is-active --quiet rsyslog; then
+  systemctl restart rsyslog
+fi
 
 %files appliance
 %defattr(-,root,root,-)

--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -99,7 +99,7 @@ fi
 
 # Disable rsyslog duplicating systemd-journal output
 # This will comment out the multi-line module load from /etc/rsyslog.conf
-sed -i '/^module(load="imjournal"/, /StateFile="imjournal.state")/ s|^|#|' %{_sysconfdir}/rsyslog.conf
+sed -i '/^module(load="imjournal"/, /^\s+StateFile="imjournal.state")/ s|^|#|' %{_sysconfdir}/rsyslog.conf
 if systemctl is-active --quiet rsyslog; then
   systemctl restart rsyslog
 fi

--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -99,7 +99,7 @@ fi
 
 # Disable rsyslog duplicating systemd-journal output
 # This will comment out the multi-line module load from /etc/rsyslog.conf
-sed -i '/module(load="imjournal"/, /StateFile="imjournal.state")/ s|^|#|' %{_sysconfdir}/rsyslog.conf
+sed -i '/^module(load="imjournal"/, /StateFile="imjournal.state")/ s|^|#|' %{_sysconfdir}/rsyslog.conf
 if systemctl is-active --quiet rsyslog; then
   systemctl restart rsyslog
 fi

--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -97,6 +97,10 @@ if systemctl is-active --quiet evm-failover-monitor; then
   systemctl restart evm-failover-monitor
 fi
 
+# Disable rsyslog duplicating systemd-journal output
+# This will comment out the multi-line module load from /etc/rsyslog.conf
+sed -i '/module(load="imjournal"/, /StateFile="imjournal.state")/ s|^|#|' %{_sysconfdir}/rsyslog.conf
+
 %files appliance
 %defattr(-,root,root,-)
 %{_sysconfdir}/default/manageiq-appliance.properties


### PR DESCRIPTION
By default systemd-journal is non-persistent and rsyslog is configured to copy everything from the journal to `/var/log/syslog`.

If you have a `/var/log/journal/` directory on persistent storage then systemd-journal will automatically persist journal files but rsyslog doesn't also automatically disable copying to syslog

TODO:
- [x] Live test of an rpm upgrade

Fixes https://github.com/ManageIQ/manageiq-rpm_build/issues/411