### PR TITLE
Lock down psych to <4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'droplet_kit',    "~>3.7",    :require => false
 gem 'manageiq-style'
 gem 'more_core_extensions'
 gem 'optimist'
+gem 'psych',          "<4"
 gem 'rake',           ">=12.3.3"
 gem 'term-ansicolor'
 


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq/pull/22727

Was causing the following error when starting the rpm_build container:
```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /root/.local/share/gem/ruby/gems/psych-5.1.1.1/ext/psych
/usr/bin/ruby -I /usr/share/rubygems -r ./siteconf20231114-3-5gt786.rb extconf.rb
checking for yaml.h... no
yaml.h not found
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib64
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/usr/bin/$(RUBY_BASE_NAME)
	--with-libyaml-source-dir
	--without-libyaml-source-dir
	--with-yaml-0.1-config
	--without-yaml-0.1-config
	--with-pkg-config
	--without-pkg-config
	--with-libyaml-dir
	--without-libyaml-dir
	--with-libyaml-include
	--without-libyaml-include=${libyaml-dir}/include
	--with-libyaml-lib
	--without-libyaml-lib=${libyaml-dir}/lib64

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /root/.local/share/gem/ruby/extensions/x86_64-linux/3.0.0/psych-5.1.1.1/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /root/.local/share/gem/ruby/gems/psych-5.1.1.1 for inspection.
Results logged to /root/.local/share/gem/ruby/extensions/x86_64-linux/3.0.0/psych-5.1.1.1/gem_make.out

  /usr/share/rubygems/rubygems/ext/builder.rb:93:in `run'
  /usr/share/rubygems/rubygems/ext/ext_conf_builder.rb:47:in `block in build'
  /usr/share/ruby/tempfile.rb:317:in `open'
  /usr/share/rubygems/rubygems/ext/ext_conf_builder.rb:26:in `build'
  /usr/share/rubygems/rubygems/ext/builder.rb:159:in `build_extension'
  /usr/share/rubygems/rubygems/ext/builder.rb:193:in `block in build_extensions'
  /usr/share/rubygems/rubygems/ext/builder.rb:190:in `each'
  /usr/share/rubygems/rubygems/ext/builder.rb:190:in `build_extensions'
  /usr/share/rubygems/rubygems/installer.rb:837:in `build_extensions'
  /usr/share/gems/gems/bundler-2.4.22/lib/bundler/rubygems_gem_installer.rb:76:in `build_extensions'
  /usr/share/gems/gems/bundler-2.4.22/lib/bundler/rubygems_gem_installer.rb:28:in `install'
  /usr/share/gems/gems/bundler-2.4.22/lib/bundler/source/rubygems.rb:203:in `install'
  /usr/share/gems/gems/bundler-2.4.22/lib/bundler/installer/gem_installer.rb:54:in `install'
  /usr/share/gems/gems/bundler-2.4.22/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /usr/share/gems/gems/bundler-2.4.22/lib/bundler/installer/parallel_installer.rb:130:in `do_install'
  /usr/share/gems/gems/bundler-2.4.22/lib/bundler/installer/parallel_installer.rb:121:in `block in worker_pool'
  /usr/share/gems/gems/bundler-2.4.22/lib/bundler/worker.rb:62:in `apply_func'
  /usr/share/gems/gems/bundler-2.4.22/lib/bundler/worker.rb:57:in `block in process_queue'
  /usr/share/gems/gems/bundler-2.4.22/lib/bundler/worker.rb:54:in `loop'
  /usr/share/gems/gems/bundler-2.4.22/lib/bundler/worker.rb:54:in `process_queue'
  /usr/share/gems/gems/bundler-2.4.22/lib/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing psych (5.1.1.1), and Bundler cannot continue.

In Gemfile:
  rspec-rails was resolved to 5.1.2, which depends on
    railties was resolved to 7.1.2, which depends on
      irb was resolved to 1.9.0, which depends on
        rdoc was resolved to 6.6.0, which depends on
          psych
[root@dcf6f5a22adb build_scripts]#
```