### PR TITLE
[MORPHY] Lock down bundler to 2.4.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,6 @@ RUN echo "gem: --no-ri --no-rdoc --no-document" > /root/.gemrc
 
 COPY . /build_scripts
 
-RUN gem install bundler
+RUN gem install bundler -v '< 2.5'
 
 ENTRYPOINT ["/build_scripts/container-assets/user-entrypoint.sh"]

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'awesome_spawn',  ">=1.3.0"
 gem 'aws-sdk-s3'
+gem 'bundler',        "< 2.5"
 gem 'config'
 gem 'droplet_kit',    "~>3.7",    :require => false
 gem 'manageiq-style'


### PR DESCRIPTION
bundler 2.5 dropped support for Ruby 2.x, so since morphy runs on 2.6, we need to lock down to bundler 2.4.x.

Similar to https://github.com/ManageIQ/manageiq/pull/22820

@agrare Please review
cc @bdunne @jrafanie 