### PR TITLE
[WIP] Faster rpm build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,14 @@ RUN npm install yarn -g
 
 RUN echo "gem: --no-ri --no-rdoc --no-document" > /root/.gemrc
 
+RUN curl -o /usr/lib/rpm/brp-strip https://raw.githubusercontent.com/rpm-software-management/rpm/rpm-4.19.1-release/scripts/brp-strip
+
+RUN chmod +x /usr/lib/rpm/brp-strip
+
 COPY . /build_scripts
+
+RUN cd /usr/lib/rpm/ && \
+  patch -p2 < /build_scripts/container-assets/Add-js-rb-filtering-on-top-of-4.19.1.patch
 
 RUN gem install bundler
 

--- a/bin/build.rb
+++ b/bin/build.rb
@@ -16,39 +16,60 @@ build_type = opts[:build_type]
 git_ref    = opts[:git_ref]
 
 # Setup source repos and build environment
+puts "XXX #{Time.now.utc} SetupSourceRepos "
 ManageIQ::RPMBuild::SetupSourceRepos.new(git_ref).populate
+puts "XXX #{Time.now.utc} SetupSourceRepos  DONE"
 
 # Generate 'ansible-venv' contents
+puts "XXX #{Time.now.utc} GenerateAnsibleVenv "
 ManageIQ::RPMBuild::GenerateAnsibleVenv.new.populate
+puts "XXX #{Time.now.utc} GenerateAnsibleVenv  DONE"
 
 # Generate 'gemset' contents
+puts "XXX #{Time.now.utc} GenerateGemSet "
 gemset = ManageIQ::RPMBuild::GenerateGemSet.new
 gemset.backup_environment_variables
 gemset.set_environment_variables
 gemset.recreate_gem_home
 gemset.populate_gem_home(build_type)
+puts "XXX #{Time.now.utc} GenerateGemSet  DONE"
 
 # Generate 'core' contents
+puts "XXX #{Time.now.utc} GenerateCore "
 ManageIQ::RPMBuild::GenerateCore.new.populate
+puts "XXX #{Time.now.utc} GenerateCore  DONE"
 
 # Scrub the gemset only after it is used to generate 'core' contents
+puts "XXX #{Time.now.utc} gemset scrub "
 gemset.scrub
+puts "XXX #{Time.now.utc} gemset scrub  DONE"
 
 # Create tarballs
+puts "XXX #{Time.now.utc} GenerateTarFiles create_tarballs "
 ManageIQ::RPMBuild::GenerateTarFiles.new.create_tarballs
+puts "XXX #{Time.now.utc} GenerateTarFiles create_tarballs  DONE"
 
 # Generate manifest with license info for gems and npm packages
+puts "XXX #{Time.now.utc} generate_dependency_manifest "
 gemset.generate_dependency_manifest
+puts "XXX #{Time.now.utc} generate_dependency_manifest  DONE"
+
+puts "XXX #{Time.now.utc} restore_environment_variables "
 gemset.restore_environment_variables
+puts "XXX #{Time.now.utc} restore_environment_variables  DONE"
 
 # Create manifest tarball
+puts "XXX #{Time.now.utc} GenerateTarFiles create_manifest_tarball "
 ManageIQ::RPMBuild::GenerateTarFiles.new.create_manifest_tarball
+puts "XXX #{Time.now.utc} GenerateTarFiles create_manifest_tarball  DONE"
 
 puts "\n\nTARBALL BUILT SUCCESSFULLY"
 
 # Build RPMs
 release_name = build_type == "release" ? git_ref : ""
+puts "XXX #{Time.now.utc} BuildCopr generate_rpm "
 ManageIQ::RPMBuild::BuildCopr.new(release_name).generate_rpm
+puts "XXX #{Time.now.utc} BuildCopr generate_rpm  DONE"
 
 if opts[:update_rpm_repo]
   ManageIQ::RPMBuild::BuildUploader.new(:release => build_type == "release").upload

--- a/bin/build_container_image
+++ b/bin/build_container_image
@@ -11,7 +11,7 @@ IMAGE_NAME=${IMAGE_NAME:-"$DEFAULT_IMAGE_NAME"}
 
 set -e
 
-docker build . -t $IMAGE_NAME
+docker build --platform=linux/x86_64 . -t $IMAGE_NAME
 
 [[ -z "$REGISTRY_USERNAME" ]] && exit 0
 

--- a/container-assets/Add-js-rb-filtering-on-top-of-4.19.1.patch
+++ b/container-assets/Add-js-rb-filtering-on-top-of-4.19.1.patch
@@ -1,0 +1,33 @@
+From 7d0f0d9c34a934327cfdd68e721c250af39a5c13 Mon Sep 17 00:00:00 2001
+From: Joe Rafaniello <jrafanie@gmail.com>
+Date: Tue, 9 Jan 2024 15:00:25 -0500
+Subject: [PATCH] Add js/rb filtering on top of 4.19.1
+
+---
+ scripts/brp-strip | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/scripts/brp-strip b/scripts/brp-strip
+index 799bf2bc2..b258debc8 100755
+--- a/scripts/brp-strip
++++ b/scripts/brp-strip
+@@ -20,6 +20,7 @@ esac
+ 
+ # Below is the explanation of commands in the order of their appearance
+ # Ignore /usr/lib/debug entries
++# Ignore all js and rb javascript and ruby files
+ # Ignore all go(guile objects & golang) files
+ # Consider files with only single link
+ # Run the file command to find relevant non-stripped binaries, with bundle size of 32
+@@ -33,6 +34,8 @@ strip_elf_binaries()
+ 
+   find "$RPM_BUILD_ROOT" -type f \
+     ! -regex "${RPM_BUILD_ROOT}/*usr/lib/debug.*" \
++    ! -name "*.js" \
++    ! -name "*.rb" \
+     ! -name "*.go" -links "${nlinks}" -print0 | \
+     xargs -0 -r -P${nprocs} -n${MAX_ARGS} sh -c "file \"\$@\" | \
+     sed -n -e 's/^\(.*\):[ 	]*ELF.*, not stripped.*/\1/p' | \
+-- 
+2.42.0
+

--- a/container-assets/user-entrypoint.sh
+++ b/container-assets/user-entrypoint.sh
@@ -19,4 +19,10 @@ fi
 
 cd /build_scripts
 bundle
-$cmd
+echo $cmd
+$cmd &
+
+while sleep 30
+do
+  echo "XXX $(date -u) Time check"
+done

--- a/lib/manageiq/rpm_build/build_copr.rb
+++ b/lib/manageiq/rpm_build/build_copr.rb
@@ -23,11 +23,11 @@ module ManageIQ
           generate_spec_from_template
 
           if File.exist?(File.expand_path("~/.config/copr"))
-            shell_cmd("rpmbuild -bs --define '_sourcedir #{RPM_SPEC_DIR}' --define '_srcrpmdir #{RPM_SPEC_DIR}' #{rpm_spec}")
+            shell_cmd("rpmbuild -bs -vv --define '_sourcedir #{RPM_SPEC_DIR}' --define '_srcrpmdir #{RPM_SPEC_DIR}' #{rpm_spec}")
             shell_cmd("copr-cli build -r epel-8-x86_64 #{rpm_repo_name} #{OPTIONS.product_name}-*.src.rpm")
           else
             arch = RUBY_PLATFORM.split("-").first
-            shell_cmd("rpmbuild -ba --define '_sourcedir #{RPM_SPEC_DIR}' --define '_srcrpmdir #{BUILD_DIR.join("rpms", arch)}' --define '_rpmdir #{BUILD_DIR.join("rpms")}' #{rpm_spec}")
+            shell_cmd("rpmbuild -ba -vv --define '_sourcedir #{RPM_SPEC_DIR}' --define '_srcrpmdir #{BUILD_DIR.join("rpms", arch)}' --define '_rpmdir #{BUILD_DIR.join("rpms")}' #{rpm_spec}")
           end
         end
       end

--- a/lib/manageiq/rpm_build/generate_tar_files.rb
+++ b/lib/manageiq/rpm_build/generate_tar_files.rb
@@ -8,10 +8,21 @@ module ManageIQ
       include Helper
 
       def create_tarballs
+puts "XXX #{Time.now.utc} create_core_tarball"
         create_core_tarball
+puts "XXX #{Time.now.utc} create_core_tarball DONE"
+
+puts "XXX #{Time.now.utc} create_gemset_tarball"
         create_gemset_tarball
+puts "XXX #{Time.now.utc} create_gemset_tarball DONE"
+
+puts "XXX #{Time.now.utc} create_appliance_tarball"
         create_appliance_tarball
+puts "XXX #{Time.now.utc} create_appliance_tarball DONE"
+
+puts "XXX #{Time.now.utc} create_ansible_venv_tarball"
         create_ansible_venv_tarball
+puts "XXX #{Time.now.utc} create_ansible_venv_tarball DONE"
       end
 
       def create_gemset_tarball

--- a/lib/manageiq/rpm_build/generate_tar_files.rb
+++ b/lib/manageiq/rpm_build/generate_tar_files.rb
@@ -22,14 +22,14 @@ module ManageIQ
         plugin_index.write(plugin_index.read.gsub(BUILD_DIR.join("manageiq").to_s, '/var/www/miq/vmdb'))
 
         name = "gemset"
-        shell_cmd("tar -C #{BUILD_DIR} -zcf #{tar_full_path(name)} -X #{exclude_file(name)} #{tar_basename(name)}")
+        shell_cmd("tar -C #{BUILD_DIR} -zcf #{tar_full_path(name)} --exclude-vcs -X #{exclude_file(name)} #{tar_basename(name)}")
       end
 
       def create_appliance_tarball
         where_am_i
 
         name = "appliance"
-        shell_cmd("tar -C #{BUILD_DIR.join("manageiq-appliance")} #{transform(name)} --exclude='.git' -hzcf #{tar_full_path(name)} .")
+        shell_cmd("tar -C #{BUILD_DIR.join("manageiq-appliance")} #{transform(name)} --exclude-vcs -hzcf #{tar_full_path(name)} .")
       end
 
       def create_core_tarball
@@ -38,21 +38,21 @@ module ManageIQ
         name = "core"
 
         # Everything from */tmp/* should be excluded, except for tmp/cache/sti_loader.yml
-        shell_cmd("tar -C #{BUILD_DIR.join("manageiq")} #{transform(name)} --exclude-tag='cache/sti_loader.yml' -X #{exclude_file("manageiq")} -hczf #{tar_full_path(name)} .")
+        shell_cmd("tar -C #{BUILD_DIR.join("manageiq")} #{transform(name)} --exclude-vcs --exclude-tag='cache/sti_loader.yml' -X #{exclude_file("manageiq")} -hczf #{tar_full_path(name)} .")
       end
 
       def create_ansible_venv_tarball
         where_am_i
 
         name = "ansible-venv"
-        shell_cmd("tar -C #{BUILD_DIR.join("manageiq-ansible-venv")} #{transform(name)} -X #{exclude_file(name)} -hzcf #{tar_full_path(name)} .")
+        shell_cmd("tar -C #{BUILD_DIR.join("manageiq-ansible-venv")} #{transform(name)} --exclude-vcs -X #{exclude_file(name)} -hzcf #{tar_full_path(name)} .")
       end
 
       def create_manifest_tarball
         where_am_i
 
         name = "manifest"
-        shell_cmd("tar -C #{BUILD_DIR.join(name)} #{transform(name)} --exclude='.git' -hzcf #{tar_full_path(name)} .")
+        shell_cmd("tar -C #{BUILD_DIR.join(name)} #{transform(name)} --exclude-vcs -hzcf #{tar_full_path(name)} .")
       end
 
       private

--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -22,6 +22,9 @@
 # Turn off the brp-python-bytecompile automagic
 %global _python_bytecompile_extra 0
 
+# Disable /usr/lib/.build-id/* artifacts
+%define _build_id_links none
+
 Name:     %{product_name}
 Version:  RPM_VERSION
 Release:  RPM_RELEASE%{?dist}

--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -22,6 +22,11 @@
 # Turn off the brp-python-bytecompile automagic
 %global _python_bytecompile_extra 0
 
+# Turn off python dependency checking
+# This was externalized in subsequent versions of rpmbuild: https://github.com/rpm-software-management/rpm/pull/1607
+%global __python_provides %{nil}
+%global __python_requires %{nil}
+
 # Disable /usr/lib/.build-id/* artifacts
 %define _build_id_links none
 


### PR DESCRIPTION
Here are some very WIP small and larger changes to try to speed up the rpm build.

My plan is to extract things we like and get them in.
* disable pythondeps - wastes 45 minutes locally... not sure if we need it, and definitely shouldn't be changing all that often.  We can possibly run this once per major change.
* final commit is just debug logging output

EDIT: 
Extracted to https://github.com/ManageIQ/manageiq-rpm_build/pull/437
* .build-id artifacts - To extract, pretty minor... tens of files are eliminated from the tarballs
* use built-in vcs to catch .git, .gitignore and friends instead of hardcoded list - seems safe to extract and it's super minor
* faster brp-strip... was 33 minutes... now around 2.  Uses new version of the file. 
