### PR TITLE
Faster rpm build step 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,11 @@ RUN echo "gem: --no-ri --no-rdoc --no-document" > /root/.gemrc
 
 COPY . /build_scripts
 
+RUN curl -o /usr/lib/rpm/brp-strip https://raw.githubusercontent.com/rpm-software-management/rpm/rpm-4.19.1-release/scripts/brp-strip && \
+  chmod +x /usr/lib/rpm/brp-strip && \
+  cd /usr/lib/rpm/ && \
+  patch -p2 < /build_scripts/container-assets/Add-js-rb-filtering-on-top-of-4.19.1.patch
+
 RUN gem install bundler
 
 ENTRYPOINT ["/build_scripts/container-assets/user-entrypoint.sh"]

--- a/container-assets/Add-js-rb-filtering-on-top-of-4.19.1.patch
+++ b/container-assets/Add-js-rb-filtering-on-top-of-4.19.1.patch
@@ -1,0 +1,33 @@
+From 7d0f0d9c34a934327cfdd68e721c250af39a5c13 Mon Sep 17 00:00:00 2001
+From: Joe Rafaniello <jrafanie@gmail.com>
+Date: Tue, 9 Jan 2024 15:00:25 -0500
+Subject: [PATCH] Add js/rb filtering on top of 4.19.1
+
+---
+ scripts/brp-strip | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/scripts/brp-strip b/scripts/brp-strip
+index 799bf2bc2..b258debc8 100755
+--- a/scripts/brp-strip
++++ b/scripts/brp-strip
+@@ -20,6 +20,7 @@ esac
+ 
+ # Below is the explanation of commands in the order of their appearance
+ # Ignore /usr/lib/debug entries
++# Ignore all js and rb javascript and ruby files
+ # Ignore all go(guile objects & golang) files
+ # Consider files with only single link
+ # Run the file command to find relevant non-stripped binaries, with bundle size of 32
+@@ -33,6 +34,8 @@ strip_elf_binaries()
+ 
+   find "$RPM_BUILD_ROOT" -type f \
+     ! -regex "${RPM_BUILD_ROOT}/*usr/lib/debug.*" \
++    ! -name "*.js" \
++    ! -name "*.rb" \
+     ! -name "*.go" -links "${nlinks}" -print0 | \
+     xargs -0 -r -P${nprocs} -n${MAX_ARGS} sh -c "file \"\$@\" | \
+     sed -n -e 's/^\(.*\):[ 	]*ELF.*, not stripped.*/\1/p' | \
+-- 
+2.42.0
+

--- a/lib/manageiq/rpm_build/generate_tar_files.rb
+++ b/lib/manageiq/rpm_build/generate_tar_files.rb
@@ -22,14 +22,14 @@ module ManageIQ
         plugin_index.write(plugin_index.read.gsub(BUILD_DIR.join("manageiq").to_s, '/var/www/miq/vmdb'))
 
         name = "gemset"
-        shell_cmd("tar -C #{BUILD_DIR} -zcf #{tar_full_path(name)} -X #{exclude_file(name)} #{tar_basename(name)}")
+        shell_cmd("tar -C #{BUILD_DIR} -zcf #{tar_full_path(name)} --exclude-vcs -X #{exclude_file(name)} #{tar_basename(name)}")
       end
 
       def create_appliance_tarball
         where_am_i
 
         name = "appliance"
-        shell_cmd("tar -C #{BUILD_DIR.join("manageiq-appliance")} #{transform(name)} --exclude='.git' -hzcf #{tar_full_path(name)} .")
+        shell_cmd("tar -C #{BUILD_DIR.join("manageiq-appliance")} #{transform(name)} --exclude-vcs -hzcf #{tar_full_path(name)} .")
       end
 
       def create_core_tarball
@@ -38,21 +38,21 @@ module ManageIQ
         name = "core"
 
         # Everything from */tmp/* should be excluded, except for tmp/cache/sti_loader.yml
-        shell_cmd("tar -C #{BUILD_DIR.join("manageiq")} #{transform(name)} --exclude-tag='cache/sti_loader.yml' -X #{exclude_file("manageiq")} -hczf #{tar_full_path(name)} .")
+        shell_cmd("tar -C #{BUILD_DIR.join("manageiq")} #{transform(name)} --exclude-vcs --exclude-tag='cache/sti_loader.yml' -X #{exclude_file("manageiq")} -hczf #{tar_full_path(name)} .")
       end
 
       def create_ansible_venv_tarball
         where_am_i
 
         name = "ansible-venv"
-        shell_cmd("tar -C #{BUILD_DIR.join("manageiq-ansible-venv")} #{transform(name)} -X #{exclude_file(name)} -hzcf #{tar_full_path(name)} .")
+        shell_cmd("tar -C #{BUILD_DIR.join("manageiq-ansible-venv")} #{transform(name)} --exclude-vcs -X #{exclude_file(name)} -hzcf #{tar_full_path(name)} .")
       end
 
       def create_manifest_tarball
         where_am_i
 
         name = "manifest"
-        shell_cmd("tar -C #{BUILD_DIR.join(name)} #{transform(name)} --exclude='.git' -hzcf #{tar_full_path(name)} .")
+        shell_cmd("tar -C #{BUILD_DIR.join(name)} #{transform(name)} --exclude-vcs -hzcf #{tar_full_path(name)} .")
       end
 
       private

--- a/rpm_spec/manageiq.spec.in
+++ b/rpm_spec/manageiq.spec.in
@@ -22,6 +22,9 @@
 # Turn off the brp-python-bytecompile automagic
 %global _python_bytecompile_extra 0
 
+# Disable /usr/lib/.build-id/* artifacts
+%define _build_id_links none
+
 Name:     %{product_name}
 Version:  RPM_VERSION
 Release:  RPM_RELEASE%{?dist}


### PR DESCRIPTION
* Don't create .build-id artifacts
* Use built-in vcs exclusion for tar to also avoid .gitignore and other vcs files
* Curl and use the rpm 4.19.1 version of brp-strip for the xargs parallel processing and filtering - add our filtering patch for ruby and js on top of it.

Extracted from https://github.com/ManageIQ/manageiq-rpm_build/pull/436

generate_rpm is about 57 minutes, total build is 1 hour 15 minutes, roughly 30 minutes faster with these changes, of which nearly all of it is the brp-strip.

EDIT:  The rpm metadata and contents looks to be just what we want changed.  I've posted an update with screenshots from the `pkgdiff -details -hide-unchanged beforeRPM afterRPM` below.
