### PR TITLE
Add ansible-core 2.12.7 to our repos

### DIFF
--- a/config/options.yml
+++ b/config/options.yml
@@ -42,6 +42,7 @@ rpm_repository:
       - el9
       :rpms:
         :ansible: !ruby/regexp /.+-5\.4.+/
+        :ansible-core: !ruby/regexp /.+-2\.12.+/
         :kafka: !ruby/regexp /.+-3\.3.+/
         :manageiq: !ruby/regexp /.+-18\.\d\.\d-(alpha|beta|rc)?\d(\.\d)?\.el.+/
         :manageiq-release: !ruby/regexp /.+-18\.0.+/


### PR DESCRIPTION
Fixes issues related to missing ansible-core-2.12 which appears to have been removed from the CentOS repos around noon today.

![image](https://github.com/ManageIQ/manageiq-rpm_build/assets/651659/3c1a6b22-01cd-4614-979b-4ae91b7ce880)
