### PR TITLE
python cryptography requires rust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN ARCH=$(uname -m) && \
       # For seeding ansible runner with ansible-galaxy, and for ansible-venv
       ansible-5.4.0-3.el8 \
       # For ansible-venv
+      cargo \
       gcc \
       krb5-devel \
       libcurl-devel \


### PR DESCRIPTION
Fixes:
```
  ERROR: Failed building wheel for cryptography
  Building wheel for tabulate (setup.py) ... done
  Created wheel for tabulate: filename=tabulate-0.8.2-py3-none-any.whl size=23529 sha256=49bce71eecb7f78bd953364fbbd4d94d67589b095a6304b9c20ac61c1d93ba4b
  Stored in directory: /root/.cache/pip/wheels/e8/2f/6e/75badca4abe8d8cacb71f1bf6958b4d3f3c45cc00612d439a9
  Building wheel for bcrypt (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Building wheel for bcrypt (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [45 lines of output]
      running bdist_wheel
      running build
      running build_py
      creating build
      creating build/lib.linux-s390x-cpython-39
      creating build/lib.linux-s390x-cpython-39/bcrypt
      copying src/bcrypt/__init__.py -> build/lib.linux-s390x-cpython-39/bcrypt
      running egg_info
      writing src/bcrypt.egg-info/PKG-INFO
      writing dependency_links to src/bcrypt.egg-info/dependency_links.txt
      writing requirements to src/bcrypt.egg-info/requires.txt
      writing top-level names to src/bcrypt.egg-info/top_level.txt
      reading manifest file 'src/bcrypt.egg-info/SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      warning: no previously-included files found matching 'requirements.txt'
      warning: no previously-included files found matching 'release.py'
      warning: no previously-included files found matching 'mypy.ini'
      warning: no previously-included files matching '*' found under directory '.github'
      warning: no previously-included files found matching 'src/_bcrypt/target'
      warning: no previously-included files matching '*' found under directory 'src/_bcrypt/target'
      adding license file 'LICENSE'
      writing manifest file 'src/bcrypt.egg-info/SOURCES.txt'
      copying src/bcrypt/__init__.pyi -> build/lib.linux-s390x-cpython-39/bcrypt
      copying src/bcrypt/py.typed -> build/lib.linux-s390x-cpython-39/bcrypt
      running build_ext
      running build_rust

          =============================DEBUG ASSISTANCE=============================
          If you are seeing a compilation error please try the following steps to
          successfully install bcrypt:
          1) Upgrade to the latest pip and try again. This will fix errors for most
             users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
          2) Ensure you have a recent Rust toolchain installed. bcrypt requires
             rustc >= 1.64.0. (1.63 may be used by setting the BCRYPT_ALLOW_RUST_163
             environment variable)

          Python: 3.9.18
          platform: Linux-5.14.0-362.13.1.el9_3.s390x-s390x-with-glibc2.34
          pip: n/a
          setuptools: 69.0.3
          setuptools_rust: 1.8.1
          rustc: 1.75.0 (82e1608df 2023-12-21) (Red Hat 1.75.0-1.el9)
          =============================DEBUG ASSISTANCE=============================

      error: [Errno 2] No such file or directory: 'cargo'
      [end of output]
```