### PR TITLE
Don't automatically detect provides and requires

### DIFF
--- a/rpm_spec/subpackages/manageiq-ansible-venv
+++ b/rpm_spec/subpackages/manageiq-ansible-venv
@@ -5,6 +5,7 @@ Summary: %{product_summary} Ansible Runner Virtual Environment
 
 Requires: ansible >= 5, ansible < 6
 Requires: python38
+AutoReqProv: no
 
 %description ansible-venv
 %{product_summary} Ansible Runner Virtual Environment


### PR DESCRIPTION
Causing:
```
Error:
 Problem 1: cannot install the best update candidate for package manageiq-ansible-venv-18.0.0-20240215165002.el9.x86_64
  - nothing provides libcrypto-401bea5d.so.1.1.1k(OPENSSL_1_1_0)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libcrypto-401bea5d.so.1.1.1k(OPENSSL_1_1_0d)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libcrypto-401bea5d.so.1.1.1k(OPENSSL_1_1_0f)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libcrypto-401bea5d.so.1.1.1k(OPENSSL_1_1_0i)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libcrypto-401bea5d.so.1.1.1k(OPENSSL_1_1_1)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libcrypto-401bea5d.so.1.1.1k(OPENSSL_1_1_1b)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libgssapi_krb5-83c4f835.so.2.2(gssapi_krb5_2_MIT)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libidn2-2f4a5893.so.0.3.6(IDN2_0.0.0)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libk5crypto-99a2d4ba.so.3.1(k5crypto_3_MIT)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libkeyutils-2777d33d.so.1.6(KEYUTILS_0.3)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libkeyutils-2777d33d.so.1.6(KEYUTILS_1.0)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libkeyutils-2777d33d.so.1.6(KEYUTILS_1.5)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libkrb5-2dfb1625.so.3.3(krb5_3_MIT)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libkrb5support-d61d84d2.so.0.1(krb5support_0_MIT)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libssh-8f1ecd37.so.4.8.7(LIBSSH_4_5_0)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libssl-52849bc7.so.1.1.1k(OPENSSL_1_1_0)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libssl-52849bc7.so.1.1.1k(OPENSSL_1_1_1)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly Problem 2: package manageiq-core-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly requires manageiq-ansible-venv = 18.0.0-20240220231925.el9, but none of the providers can be installed
  - cannot install the best update candidate for package manageiq-core-18.0.0-20240215165002.el9.x86_64
  - nothing provides libcrypto-401bea5d.so.1.1.1k(OPENSSL_1_1_0)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libcrypto-401bea5d.so.1.1.1k(OPENSSL_1_1_0d)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libcrypto-401bea5d.so.1.1.1k(OPENSSL_1_1_0f)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libcrypto-401bea5d.so.1.1.1k(OPENSSL_1_1_0i)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libcrypto-401bea5d.so.1.1.1k(OPENSSL_1_1_1)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libcrypto-401bea5d.so.1.1.1k(OPENSSL_1_1_1b)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libgssapi_krb5-83c4f835.so.2.2(gssapi_krb5_2_MIT)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libidn2-2f4a5893.so.0.3.6(IDN2_0.0.0)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libk5crypto-99a2d4ba.so.3.1(k5crypto_3_MIT)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libkeyutils-2777d33d.so.1.6(KEYUTILS_0.3)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libkeyutils-2777d33d.so.1.6(KEYUTILS_1.0)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libkeyutils-2777d33d.so.1.6(KEYUTILS_1.5)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libkrb5-2dfb1625.so.3.3(krb5_3_MIT)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libkrb5support-d61d84d2.so.0.1(krb5support_0_MIT)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libssh-8f1ecd37.so.4.8.7(LIBSSH_4_5_0)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libssl-52849bc7.so.1.1.1k(OPENSSL_1_1_0)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly
  - nothing provides libssl-52849bc7.so.1.1.1k(OPENSSL_1_1_1)(64bit) needed by manageiq-ansible-venv-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly Problem 3: package manageiq-core-services-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly requires manageiq-core = 18.0.0-20240220231925.el9, but none of the providers can be installed
  - package manageiq-core-18.0.0-20240220231925.el9.x86_64 from manageiq-18-radjabov-nightly requires manageiq-ansible-venv = 18.0.0-20240220231925.el9, but none of the providers can be installed ...
```