### PR TITLE
Remove any Gemfile.lock files shipped in gems

### DIFF
--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -173,6 +173,9 @@ module ManageIQ
           # Remove ffi ext directory, this causes rpm build failure
           FileUtils.rm_rf(Dir.glob("gems/ffi-*/ext"))
 
+          # Remove Gemfile.lock files shipped by gems.  They are not a problem, but flagged by some scanners and they shouldn't be shipped with gems anyway
+          FileUtils.rm_rf(Dir.glob("gems/*/Gemfile.lock"))
+
           ["gems", "bundler/gems"].each do |path|
             FileUtils.rm_rf(Dir.glob("#{path}/**/*.o"))
             FileUtils.rm_rf(Dir.glob("#{path}/*/docs"))


### PR DESCRIPTION
They shouldn't be packaged as they are only for development/test purposes.

Example:
[root@93085f55cd7e vmdb]# find / -name Gemfile.lock 
/var/www/miq/vmdb/Gemfile.lock
/opt/...-gemset/gems/ibm_cloud_power-2.1.1/Gemfile.lock
/opt/...-gemset/gems/terminal-2.0.0/Gemfile.lock
/opt/...-gemset/gems/macaddr-1.7.2/Gemfile.lock
/opt/...-gemset/gems/os-1.1.4/Gemfile.lock
/opt/...-gemset/gems/net-ping-1.7.8/Gemfile.lock
/opt/...-gemset/gems/high_voltage-3.0.0/Gemfile.lock
/opt/...-gemset/gems/webpacker-2.0/Gemfile.lock
/opt/...-gemset/vmdb/Gemfile.lock

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
