### PR TITLE
[quinteros] Update version numbers for Quinteros-1 build and fix rpm issue

### DIFF
--- a/config/options.yml
+++ b/config/options.yml
@@ -14,7 +14,7 @@ repos:
 version:
 release:
 rpm:
-  version: 17.1.0
+  version: 17.1.1
   release: 1
   repo_name:
   org_name: manageiq
@@ -39,7 +39,6 @@ rpm_repository:
     :17-quinteros:
       :targets:
       - el8
-      - el9
       :rpms:
         :ansible: !ruby/regexp /.+-5\.4.+/
         :ansible-core: !ruby/regexp /.+-2\.12.+/
@@ -56,6 +55,5 @@ rpm_repository:
     :17-quinteros-nightly:
       :targets:
       - el8
-      - el9
       :rpms:
         :manageiq-nightly: !ruby/regexp /.+-17\.\d\.\d-(\d\.\d\.)?\d{14,}+\.el.+/

--- a/rpm_spec/changelog
+++ b/rpm_spec/changelog
@@ -1,4 +1,7 @@
 %changelog
+* Mon Apr 01 2024 ManageIQ <contact@manageiq.org> - 17.1.1-1
+- Quinteros 1 build
+
 * Fri Feb 23 2024 ManageIQ <contact@manageiq.org> - 17.1.0-1
 - Quinteros 1 build
 

--- a/rpm_spec/subpackages/manageiq-ansible-venv
+++ b/rpm_spec/subpackages/manageiq-ansible-venv
@@ -5,6 +5,7 @@ Summary: %{product_summary} Ansible Runner Virtual Environment
 
 Requires: ansible >= 5, ansible < 6
 Requires: python38
+AutoReqProv: no
 
 %description ansible-venv
 %{product_summary} Ansible Runner Virtual Environment


### PR DESCRIPTION
We already have 17.1.0-timestamp nightly builds that RPM would incorrectly see as newer than 17.1.0-1.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
