### PR TITLE
Revert "Temporarily lock down to ruby 3.1.2-142"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,7 @@ RUN ARCH=$(uname -m) && \
       platform-python-devel \
       postgresql-server \
       qpid-proton-c-devel \
-      ruby-default-gems-3.1.2 \
-      ruby-devel-3.1.2 \
+      ruby-devel \
       wget \
       # For seeding ansible runner with ansible-galaxy, and for ansible-venv
       ansible \

--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -1,9 +1,9 @@
 %package core
 Summary:  %{product_summary} Core
 
-Requires: ruby = 3.1.2
+Requires: ruby >= 3.1
 # Include weak dependencies of Ruby that we actually need
-Requires: ruby-default-gems = 3.1.2
+Requires: ruby-default-gems
 Requires: rubygem-bigdecimal
 Requires: rubygem-io-console
 Requires: rubygem-irb


### PR DESCRIPTION
This reverts commit 80c4051a1f03f4082dd4a5c78e06ab4c1d7e8af0.

This was locked down due to different package versions being available in UBI 9 and CentOS Stream 9.  Now that ruby 3.1.4 has been released in CentOS Stream 9 we can unlock it