### PR TITLE
Switch from UBI openssl-libs to Stream openssl-libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN ARCH=$(uname -m) && \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
       https://rpm.manageiq.org/release/19-spassky/el9/noarch/manageiq-release-19.0-1.el9.noarch.rpm && \
     dnf -y --disablerepo=ubi-9-baseos-rpms swap openssl-fips-provider openssl-libs && \
+    dnf -y update && \
     dnf -y module enable ruby:3.1 && \
     dnf -y module enable nodejs:18 && \
     dnf -y group install "development tools" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN ARCH=$(uname -m) && \
     dnf -y install \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
       https://rpm.manageiq.org/release/19-spassky/el9/noarch/manageiq-release-19.0-1.el9.noarch.rpm && \
+    dnf -y --disablerepo=ubi-9-baseos-rpms swap openssl-fips-provider openssl-libs && \
     dnf -y module enable ruby:3.1 && \
     dnf -y module enable nodejs:18 && \
     dnf -y group install "development tools" && \


### PR DESCRIPTION
Related: https://github.com/ManageIQ/manageiq-pods/pull/1096

The openssl-libs sub-package in RHEL/UBI 9 requires openssl-fips-provider which is not available in the CentOS Stream 9 repo.  For some reason upgrading from the UBI 9 v3.0 package to the Stream 9 v3.2 package does not uninstall openssl-fips-provider which was only required by the UBI 9 openssl-libs package.  Since openssl-fips-provider provides some of the same files as the Stream 9 openssl-libs, we need to remove it in order to upgrade.  I only see openssl-fips-provider required by openssl-libs so removal should be safe.

Previous error:
```
[root@e03bd374fadd /]# dnf --disablerepo=ubi-9-baseos-rpms upgrade openssl-libs Last metadata expiration check: 0:01:15 ago on Thu May  2 19:58:32 2024. Dependencies resolved.
==============================================================================================================================================================================================================================================
 Package                                                     Architecture                                          Version                                                        Repository                                             Size
==============================================================================================================================================================================================================================================
Upgrading:
 openssl                                                     x86_64                                                1:3.2.1-1.el9                                                  baseos                                                1.3 M
 openssl-libs                                                x86_64                                                1:3.2.1-1.el9                                                  baseos                                                2.4 M

Transaction Summary
============================================================================================================================================================================================================================================== Upgrade  2 Packages

Total size: 3.7 M
Is this ok [y/N]: y
Downloading Packages:
[SKIPPED] openssl-3.2.1-1.el9.x86_64.rpm: Already downloaded [SKIPPED] openssl-libs-3.2.1-1.el9.x86_64.rpm: Already downloaded Running transaction check
Transaction check succeeded.
Running transaction test
The downloaded packages were saved in cache until the next successful transaction. You can remove cached packages by executing 'dnf clean packages'. Error: Transaction test error:
  file /usr/lib64/ossl-modules/fips.so from install of openssl-libs-1:3.2.1-1.el9.x86_64 conflicts with file from package openssl-fips-provider-3.0.7-2.el9.x86_64
```