### PR TITLE
Openssl lockdown to <v3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,6 @@ RUN ARCH=$(uname -m) && \
     dnf -y install \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
       https://rpm.manageiq.org/release/19-spassky/el9/noarch/manageiq-release-19.0-1.el9.noarch.rpm && \
-    dnf -y --disablerepo=ubi-9-baseos-rpms swap openssl-fips-provider openssl-libs && \
-    dnf -y update && \
     dnf -y module enable ruby:3.1 && \
     dnf -y module enable nodejs:18 && \
     dnf -y group install "development tools" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN ARCH=$(uname -m) && \
     dnf -y module enable ruby:3.1 && \
     dnf -y module enable nodejs:18 && \
     dnf -y group install "development tools" && \
-    dnf config-manager --setopt=tsflags=nodocs --save && \
+    dnf config-manager --save --setopt=tsflags=nodocs --setopt=exclude=openssl*-3.2* && \
     dnf -y install \
       cmake \
       copr-cli \

--- a/rpm_spec/subpackages/manageiq-gemset
+++ b/rpm_spec/subpackages/manageiq-gemset
@@ -12,7 +12,7 @@ Requires: libxml2
 Requires: libxslt
 Requires: nfs-utils
 Requires: openscap-scanner
-Requires: openssl
+Requires: openssl >= 1:3.0, openssl < 1:3.2
 
 # For Miq IPMI (gems-pending)
 Requires: OpenIPMI


### PR DESCRIPTION
- Revert upgrade to openssl v3.2 (https://github.com/ManageIQ/manageiq-rpm_build/pull/457)
- Lock down to openssl < v3.2 for now