### PR TITLE
Add postgresql-contrib package

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -6,6 +6,7 @@ Requires: %{name}-ui = %{version}-%{release}
 Requires: %{name}-core-services = %{version}-%{release}
 Requires: %{name}-gemset-services = %{version}-%{release}
 
+Requires: postgresql-contrib >= 13
 Requires: postgresql-server >= 13
 Requires: repmgr13 >= 5.2.1
 


### PR DESCRIPTION
This is currently needed because the opentofu runner needs the uuid-ossp extension.

@bdunne @agrare @putmanoj Please review.