### PR TITLE
[morphy] CentOS Stream8 EOL

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+rpm_cache/*.rpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.4
+FROM registry.access.redhat.com/ubi8/ubi
 
 ARG ARCH=x86_64
 
@@ -13,8 +13,8 @@ RUN curl -L https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo 
 
 RUN dnf -y remove subscription-manager* && \
     dnf -y update && \
-    if [ ${ARCH} != "s390x" ] ; then dnf -y install http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \
-                                                    http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm; fi && \
+    if [ ${ARCH} != "s390x" ] ; then dnf -y install https://rpm.manageiq.org/builds/centos/centos-stream-repos-8-6.1.el8.noarch.rpm \
+                                                    https://rpm.manageiq.org/builds/centos/centos-gpg-keys-8-6.1.el8.noarch.rpm; fi && \
     dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
                    https://rpm.manageiq.org/release/13-morphy/el8/noarch/manageiq-release-13.0-1.el8.noarch.rpm && \
     dnf -y module enable ruby:2.6 && \

--- a/packages/manageiq-ansible-venv/Dockerfile
+++ b/packages/manageiq-ansible-venv/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.4
+FROM registry.access.redhat.com/ubi8/ubi
 
 ARG ARCH=x86_64
 
@@ -15,8 +15,8 @@ ENV RPM_SPEC=manageiq-ansible-venv.spec \
 # EPEL: copr-cli
 RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/subscription-manager.conf
 RUN dnf -y install \
-      http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \
-      http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm \
+      https://rpm.manageiq.org/builds/centos/centos-stream-repos-8-6.1.el8.noarch.rpm \
+      https://rpm.manageiq.org/builds/centos/centos-gpg-keys-8-6.1.el8.noarch.rpm \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     dnf config-manager --setopt=tsflags=nodocs --save && \
     dnf -y install \


### PR DESCRIPTION
Related:
- https://github.com/ManageIQ/manageiq-pods/pull/1118
- https://github.com/ManageIQ/manageiq-appliance-build/pull/571

Unfortunately the repos RPM in the vault still points to mirrors.centos.org which is no longer serving Stream 8.  I patched the RPMs and posted them on rpm.manageiq.org with a change to point all repos to the vault.
