### PR TITLE
[morphy] Lockdown term-ansicolor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'manageiq-style'
 gem 'more_core_extensions'
 gem 'optimist'
 gem 'rake',           ">=12.3.3"
-gem 'term-ansicolor'
+gem 'term-ansicolor', "< 1.9.0"
 
 group :test do
   gem "rspec-rails", "~>4.0"


### PR DESCRIPTION
1.9.0 is causing build failures:

```
/root/.gem/ruby/gems/term-ansicolor-1.9.0/lib/term/ansicolor/attribute.rb:98:in `initialize': undefined method `start_with?' for :clear:Symbol (NoMethodError)
	from /root/.gem/ruby/gems/term-ansicolor-1.9.0/lib/term/ansicolor/attribute.rb:23:in `new'
	from /root/.gem/ruby/gems/term-ansicolor-1.9.0/lib/term/ansicolor/attribute.rb:23:in `set'
	from /root/.gem/ruby/gems/term-ansicolor-1.9.0/lib/term/ansicolor/attribute/text.rb:5:in `<class:Text>'
	from /root/.gem/ruby/gems/term-ansicolor-1.9.0/lib/term/ansicolor/attribute/text.rb:4:in `<class:Attribute>'
	from /root/.gem/ruby/gems/term-ansicolor-1.9.0/lib/term/ansicolor/attribute/text.rb:3:in `<module:ANSIColor>'
	from /root/.gem/ruby/gems/term-ansicolor-1.9.0/lib/term/ansicolor/attribute/text.rb:2:in `<module:Term>'
	from /root/.gem/ruby/gems/term-ansicolor-1.9.0/lib/term/ansicolor/attribute/text.rb:1:in `<top (required)>'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:65:in `require'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:65:in `require'
	from /root/.gem/ruby/gems/term-ansicolor-1.9.0/lib/term/ansicolor.rb:13:in `<module:ANSIColor>'
	from /root/.gem/ruby/gems/term-ansicolor-1.9.0/lib/term/ansicolor.rb:7:in `<module:Term>'
	from /root/.gem/ruby/gems/term-ansicolor-1.9.0/lib/term/ansicolor.rb:3:in `<top (required)>'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:130:in `require'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:130:in `rescue in require'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:34:in `require'
	from /build_scripts/lib/manageiq/rpm_build.rb:5:in `<top (required)>'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
	from bin/build.rb:5:in `<main>'
/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- term/ansicolor (LoadError)
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /build_scripts/lib/manageiq/rpm_build.rb:5:in `<top (required)>'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
	from bin/build.rb:5:in `<main>'
```