### PR TITLE
[morphy] Merge pull request #289 from Fryguy/weak_deps

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -2,6 +2,11 @@
 Summary:  %{product_summary} Core
 
 Requires: ruby
+# Include weak dependencies of Ruby that we actually need
+Requires: rubygem-bigdecimal
+Requires: rubygem-io-console
+Requires: rubygem-irb
+
 Requires: %{name}-gemset = %{version}-%{release}
 
 Requires: ansible >= 5, ansible < 6


### PR DESCRIPTION
Include weak dependencies of Ruby that we actually need

(cherry picked from commit 97aa8f9d54d93f5bf39c1d062f79570238ffaaf2) 

**Modified to remove ruby-default-gems since that does not exist in this version**

Requires backport of https://github.com/ManageIQ/manageiq-pods/pull/847
