### PR TITLE
[quinteros] Allow timestamped release builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN ARCH=$(uname -m) && \
     if [ ${ARCH} != "s390x" ] ; then dnf -y remove *subscription-manager*; fi && \
     dnf -y update && \
     if [ ${ARCH} != "s390x" ] ; then dnf -y install \
-      http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \
-      http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm ; fi && \
+      https://rpm.manageiq.org/builds/centos/centos-stream-repos-8-6.1.el8.noarch.rpm \
+      https://rpm.manageiq.org/builds/centos/centos-gpg-keys-8-6.1.el8.noarch.rpm ; fi && \
     dnf -y install \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
       https://rpm.manageiq.org/release/17-quinteros/el8/noarch/manageiq-release-17.0-1.el8.noarch.rpm && \

--- a/config/options.yml
+++ b/config/options.yml
@@ -43,7 +43,7 @@ rpm_repository:
         :ansible: !ruby/regexp /.+-5\.4.+/
         :ansible-core: !ruby/regexp /.+-2\.12.+/
         :kafka: !ruby/regexp /.+-3\.3.+/
-        :manageiq: !ruby/regexp /.+-17\.\d\.\d-(alpha|beta|rc)?\d(\.\d)?\.el.+/
+        :manageiq: !ruby/regexp /.+-17\.\d\.\d-(alpha|beta|rc)?\d+(\.\d)?\.el.+/
         :manageiq-release: !ruby/regexp /.+-17\.0.+/
         :python-bambou: !ruby/regexp /.+-3\.1\.1.+/
         :python-pylxca: !ruby/regexp /.+-2\.1\.1.+/

--- a/lib/manageiq/rpm_build/rpm_repo.rb
+++ b/lib/manageiq/rpm_build/rpm_repo.rb
@@ -24,7 +24,7 @@ module ManageIQ
           puts "Downloading required RPMs..."
           OPTIONS.rpm_repository.content.each do |branch, values|
             values[:rpms]&.each do |rpm, version_regex|
-              client.list_objects(:bucket => OPTIONS.rpm_repository.s3_api.bucket, :prefix => File.join("builds", rpm.to_s)).flat_map(&:contents).each do |object|
+              client.list_objects(:bucket => OPTIONS.rpm_repository.s3_api.bucket, :prefix => File.join("builds", rpm.to_s, "/")).flat_map(&:contents).each do |object|
                 file = object.key
                 name = File.basename(file)
                 *, target, arch, _rpm = name.split(".")

--- a/spec/config/options_spec.rb
+++ b/spec/config/options_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "options.yml" do
 
         nightly_versions.each do |version|
           file = ["manageiq", suffix, version].compact.join("-") + ".el8.x86_64.rpm"
-          include_examples("expect_excluded_rpm", file, "manageiq")
+          include_examples("expect_included_rpm", file, "manageiq")
         end
       end
     end


### PR DESCRIPTION
- Allow timestamped RPMs in the release repo if they're in the release dir
- Ensure the prefix ends with a /
    This ensures that nightly builds from the manageiq-nightly directory are not included in the release repo when searching for release builds.
    "builds/manageiq/" vs. "builds/manageiq" which would include "builds/manageiq-nightly"

Fixes: https://github.com/orgs/ManageIQ/discussions/23135
Needs to be forward-ported to radjabov and master