### PR TITLE
\s+ wasn't matching multiple spaces and failed to match the last line commenting out the rest of the file.

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -99,7 +99,7 @@ fi
 
 # Disable rsyslog duplicating systemd-journal output
 # This will comment out the multi-line module load from /etc/rsyslog.conf
-sed -i '/^module(load="imjournal"/, /^\s+StateFile="imjournal.state")/ s|^|#|' %{_sysconfdir}/rsyslog.conf
+sed -i '/^module(load="imjournal"/, /^\s\+StateFile="imjournal.state")/ s|^|#|' %{_sysconfdir}/rsyslog.conf
 if systemctl is-active --quiet rsyslog; then
   systemctl restart rsyslog
 fi


### PR DESCRIPTION
The + needs to be escaped for it to match the last line

Example failure:
```
× rsyslog.service - System Logging Service
     Loaded: loaded (/usr/lib/systemd/system/rsyslog.service; enabled; preset: enabled)
     Active: failed (Result: exit-code) since Wed 2024-08-21 09:45:27 EDT; 18min ago
       Docs: man:rsyslogd(8)
             https://www.rsyslog.com/doc/
    Process: 37598 ExecStart=/usr/sbin/rsyslogd -n $SYSLOGD_OPTIONS (code=exited, status=1/FAILURE)
   Main PID: 37598 (code=exited, status=1/FAILURE)
        CPU: 69ms

Aug 21 09:45:27 mmim421.example.com systemd[1]: rsyslog.service: Scheduled restart job, restart counter is at 5.
Aug 21 09:45:27 mmim421.example.com systemd[1]: Stopped System Logging Service.
Aug 21 09:45:27 mmim421.example.com systemd[1]: rsyslog.service: Start request repeated too quickly.
Aug 21 09:45:27 mmim421.example.com systemd[1]: rsyslog.service: Failed with result 'exit-code'.
Aug 21 09:45:27 mmim421.example.com systemd[1]: Failed to start System Logging Service.
```