### PR TITLE
Bring back syslog lines that were incorrectly disabled

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -100,6 +100,8 @@ fi
 # Disable rsyslog duplicating systemd-journal output
 # This will comment out the multi-line module load from /etc/rsyslog.conf
 sed -i '/^module(load="imjournal"/, /^\s\+StateFile="imjournal.state")/ s|^|#|' %{_sysconfdir}/rsyslog.conf
+# fix rsyslog entries that were previously over commented out
+sed -i '/^##module(load="imklog")/,$ s/^#//g' %{_sysconfdir}/rsyslog.conf
 if systemctl is-active --quiet rsyslog; then
   systemctl restart rsyslog
 fi


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq-rpm_build/pull/484

We commented out imjournal via sed when installing the appliance. Unfortunately, instead of commenting out just the imjournal, we commented out to the end of the file.

This script removes all those extra comments to the end of the file.

There is a chance that we will incorrectly remove comments.
This will happen if the user has `##module(load="imklog")`
If support general appliances, then we may have to factor this unlikely scenario
