### PR TITLE
Fix already broken rsyslog on appliances

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -100,6 +100,7 @@ fi
 # Disable rsyslog duplicating systemd-journal output
 # This will comment out the multi-line module load from /etc/rsyslog.conf
 sed -i '/^module(load="imjournal"/, /^\s\+StateFile="imjournal.state")/ s|^|#|' %{_sysconfdir}/rsyslog.conf
+sed -i '/^##module(load="imklog")/,$ s|^#||' %{_sysconfdir}/rsyslog.conf
 if systemctl is-active --quiet rsyslog; then
   systemctl restart rsyslog
 fi


### PR DESCRIPTION
Followup to #484
If the "load imklog" line (first line after our commented section) is double commented, remove the first comment from every line in the rest of the file.  Fixes appliances that were broken before #484 due to the rest of the file being commented out.

Example of the bad state:
```
# rsyslog configuration file

# For more information see /usr/share/doc/rsyslog-*/rsyslog_conf.html # or latest version online at http://www.rsyslog.com/doc/rsyslog_conf.html # If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html

#### GLOBAL DIRECTIVES ####

# Where to place auxiliary files
global(workDirectory="/var/lib/rsyslog")

# Use default timestamp format
module(load="builtin:omfile" Template="RSYSLOG_TraditionalFileFormat")

#### MODULES ####

module(load="imuxsock" 	  # provides support for local system logging (e.g. via logger command)
       SysSock.Use="off") # Turn off message reception via local log socket;
			  # local messages are retrieved through imjournal now.
#module(load="imjournal" 	    # provides access to the systemd journal
#       UsePid="system" # PID nummber is retrieved as the ID of the process the journal entry originates from
#       FileCreateMode="0644" # Set the access permissions for the state file
#       StateFile="imjournal.state") # File to store the position in the journal
##module(load="imklog") # reads kernel messages (the same are read from journald)
##module(load="immark") # provides --MARK-- message capability
#
## Include all config files in /etc/rsyslog.d/
#include(file="/etc/rsyslog.d/*.conf" mode="optional")
#
## Provides UDP syslog reception
## for parameters see http://www.rsyslog.com/doc/imudp.html
##module(load="imudp") # needs to be done just once
##input(type="imudp" port="514")
#
## Provides TCP syslog reception
## for parameters see http://www.rsyslog.com/doc/imtcp.html
##module(load="imtcp") # needs to be done just once
##input(type="imtcp" port="514")
#
##### RULES ####
#
## Log all kernel messages to the console.
## Logging much else clutters up the screen.
##kern.*                                                 /dev/console
#
## Log anything (except mail) of level info or higher.
## Don't log private authentication messages!
#*.info;mail.none;authpriv.none;cron.none                /var/log/messages
#
## The authpriv file has restricted access.
#authpriv.*                                              /var/log/secure
#
## Log all the mail messages in one place.
#mail.*                                                  -/var/log/maillog
#
#
## Log cron stuff
#cron.*                                                  /var/log/cron
#
## Everybody gets emergency messages
#*.emerg                                                 :omusrmsg:*
#
## Save news errors of level crit and higher in a special file.
#uucp,news.crit                                          /var/log/spooler
#
## Save boot messages also to boot.log
#local7.*                                                /var/log/boot.log
#
#
## ### sample forwarding rule ###
##action(type="omfwd"
## # An on-disk queue is created for this action. If the remote host is
## # down, messages are spooled to disk and sent when it is up again.
##queue.filename="fwdRule1"       # unique name prefix for spool files
##queue.maxdiskspace="1g"         # 1gb space limit (use as much as possible)
##queue.saveonshutdown="on"       # save messages to disk on shutdown
##queue.type="LinkedList"         # run asynchronously
##action.resumeRetryCount="-1"    # infinite retries if host is down
## # Remote Logging (we use TCP for reliable delivery)
## # remote_host is: name/ip, e.g. 192.168.0.1, port optional e.g. 10514
##Target="remote_host" Port="XXX" Protocol="tcp")
```