### PR TITLE
Revert "Merge pull request #458 from bdunne/openssl_fix_2"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,12 @@ RUN ARCH=$(uname -m) && \
     dnf -y install \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
       https://rpm.manageiq.org/release/19-spassky/el9/noarch/manageiq-release-19.0-1.el9.noarch.rpm && \
+    dnf -y --disablerepo=ubi-9-baseos-rpms swap openssl-fips-provider openssl-libs && \
+    dnf -y update && \
     dnf -y module enable ruby:3.1 && \
     dnf -y module enable nodejs:18 && \
     dnf -y group install "development tools" && \
-    dnf config-manager --save --setopt=tsflags=nodocs --setopt=exclude=openssl*-3.2* && \
+    dnf config-manager --setopt=tsflags=nodocs --save && \
     dnf -y install \
       cmake \
       copr-cli \

--- a/rpm_spec/subpackages/manageiq-gemset
+++ b/rpm_spec/subpackages/manageiq-gemset
@@ -12,7 +12,7 @@ Requires: libxml2
 Requires: libxslt
 Requires: nfs-utils
 Requires: openscap-scanner
-Requires: openssl >= 1:3.0, openssl < 1:3.2
+Requires: openssl
 
 # For Miq IPMI (gems-pending)
 Requires: OpenIPMI


### PR DESCRIPTION
This reverts commit e5f8e5fc01c2370b3ae16eb47846055deb453782, reversing changes made to a3d5b42577749798f4f1e469fed007305dee906a.

Revert the openssl-libs lockdown and allow v3.2.2-4.  3.2.1-1 was causing segfaults, hopefully the new version is fixed?

Alternatively, we can lock down libcurl-devel as well and stick with openssl-libs 3.0.

All builds are currently broken on EL9 until we pick a path forward.

Related:
- https://github.com/ManageIQ/manageiq-rpm_build/pull/458
- https://github.com/ManageIQ/manageiq-rpm_build/pull/457