### PR TITLE
remove aiohttp

### DIFF
--- a/bin/requirements.rb
+++ b/bin/requirements.rb
@@ -36,7 +36,6 @@ class ParseRequirements
     openstack/cloud/requirements.txt
     ovirt/ovirt/requirements.txt
     theforeman/foreman/requirements.txt
-    vmware/vmware_rest/requirements.txt
   ]
   attr_reader :filenames, :non_modules, :final
 

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,4 +1,3 @@
-aiohttp # vmware/vmware_rest
 ansible-pylibssh>=0.2.0 # ansible/netcommon
 apache-libcloud # legacy
 awxkit # awx/awx


### PR DESCRIPTION
This was added to support all possible vmware clients But we don't use this client, none of our customers requested it and it looks to have security issues

@Fryguy your call if we want to go this route or want to resolve the issues

This resolves quite a few Mend issues (High and Medium) like https://github.com/ManageIQ/manageiq-rpm_build/issues/501 and https://github.com/ManageIQ/manageiq-rpm_build/issues/502