### PR TITLE
Update requirements for python dependencies

### DIFF
--- a/bin/requirements.rb
+++ b/bin/requirements.rb
@@ -4,23 +4,40 @@
 # and updates it with the version for our supported packages
 #
 # USAGE:
+#
 # 1. Setup environment
 #
-#     source /var/lib/manageiq/venv/bin/activate
 #     upload bin/requirements.rb and config/requirements.txt to /tmp
+#     source /var/lib/manageiq/venv/bin/activate
 #     chmod 755 requirements.rb
 #
-# 1. Get all module requirements (don't include documentation or testing ones)
+# 2. Determine all python packages provided by rpms (and compare with OS_PACKAGES)
+#
+#     TODO: may want to grep rpm contents with 'info$' to determine elgibility.
+#
+#     for pkg in $(rpm -qa | grep python3-) ; do echo "### $pkg" ; rpm -ql $pkg | awk  -F/ '/site-packages/ { print $6 }' | sort -u ; done
+#
+# 3. Get all module requirements (don't include documentation or testing ones)
 #
 #     ./requirements.rb ./requirements.txt /usr/lib/python3.9/site-packages/ansible_collections/ > new_requirements.txt
 #
-# 2. Resolve conflicts and determine if new one is correct
+# 4. Resolve conflicts and determine if new one is correct
 #
 #     diff {,new_}requirements.txt
 #     # cp new_requirements.txt requirements.txt
 #
-
+# 5. Update dev riles
+#
+#     download /tmp/requirements{.rb,.txt} to local machine
+#     create a PR with updates
+#
 class ParseRequirements
+  # this is the list of packages provided by rpms
+  # TODO: paramiko
+  OS_PACKAGES=%w[
+    six dateutil iniparse idna setuptools inotify libcomps chardet decorator pysocks urllib3 requests
+    cloud-what systemd dbus gobject gpg pyspnego
+  ]
   PACKAGES=%w[
     amazon/aws/requirements.txt
     ansible/netcommon/requirements.txt
@@ -38,13 +55,18 @@ class ParseRequirements
     theforeman/foreman/requirements.txt
     vmware/vmware_rest/requirements.txt
   ]
-  attr_reader :filenames, :non_modules, :final
+  attr_reader :filenames, :non_modules, :final, :verbose
 
   def initialize
     @filenames = []
     @non_modules = []
 
     @final = {}
+    @verbose = false
+  end
+
+  def verbose!
+    @verbose = true
   end
 
   def add_target(filename)
@@ -90,8 +112,8 @@ class ParseRequirements
         # skip git libraries. git>= line from vsphere gave us problems
         next if lib.start_with?("git")
 
-        # Do not version packages that are provided by the system: requests, requests[security], pyspnego[kerberos]
-        ver = "" if lib.match?(/^requests($|\[)/) || lib.start_with?("pyspnego")
+        # system packages are versioned by rpms
+        ver = "" if lib.match?(/^(#{OS_PACKAGES.join("|")})($|\[)/)
 
         final[lib] ||= {}
         (final[lib][ver] ||= []) << mod
@@ -110,18 +132,22 @@ class ParseRequirements
           higher, lower, conflict = version_compare(alt, max_key)
           # There is a conflict when we have conflicting requirements. eg: >=2.0 and ==1.0
           # We are displaying all comparisons/winners to verify the comparison algorithm works (skipping when merging a blank - no change of errors there)
-          $stderr.puts "#{lib}: #{higher} > #{lower} #{"CONFLICT" if conflict}" if lower != ""
+          $stderr.puts "#{lib}: #{higher} > #{lower} #{"CONFLICT" if conflict}" if lower != "" || verbose
           vers[higher].concat(vers.delete(lower))
           max_key = higher
         end
       end
 
-      vers.map do |(ver, modules)|
-        # if we pass in a previous requirements.txt, lets not mention it
-        # exception: display if it is only mentioned in a previous requirements.txt file
-        modules.delete("legacy") if modules.size > 1
-        "#{lib}#{ver} # #{modules.join(", ")}"
-      end
+      ver = vers.keys.first
+      modules = vers[ver]
+      # if we pass in a previous requirements.txt, lets not mention it
+      # exception: display if it is only mentioned in a previous requirements.txt file
+      modules.delete("legacy") if modules.size > 1
+
+      # clear out versions for packages provided by the operatingsystem like requests, requests[security], and pyspnego
+      ver = "" if OS_PACKAGES.include?(lib.gsub(/\[.*\]/))
+
+      "#{lib}#{ver} # #{modules.join(", ")}"
     end.sort.join("\n")
 
     puts result
@@ -204,4 +230,5 @@ end
 
 pr = ParseRequirements.new
 ARGV.each { |arg| pr.add_target(arg) }
+pr.verbose! if ENV["VERBOSE"]
 pr.parse.output

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -6,7 +6,7 @@ azure-cli-core==2.34.0 # azure/azcollection
 azure-common==1.1.11 # azure/azcollection
 azure-containerregistry==1.1.0 # azure/azcollection
 azure-graphrbac==0.61.1 # azure/azcollection
-azure-identity==1.7.0 # azure/azcollection
+azure-identity>=1.16.0 # azure/azcollection
 azure-keyvault==1.1.0 # azure/azcollection
 azure-mgmt-apimanagement==3.0.0 # azure/azcollection
 azure-mgmt-authorization==2.0.0 # azure/azcollection
@@ -53,22 +53,22 @@ boto3>=1.18.0 # amazon/aws, community/aws
 botocore>=1.21.0 # amazon/aws, community/aws
 cryptography>=36.0.0 # cisco/intersight
 deprecation # legacy
-google-auth==1.6.2 # google/cloud
+google-auth # google/cloud
 google-cloud-storage # google/cloud
 grpcio # ansible/netcommon
 jsonpatch # kubernetes/core
-jsonschema # ansible/utils
+jsonschema>=4.18.0 # ansible/utils
 jxmlease # ansible/netcommon
 kubernetes>=12.0.0 # community/okd, kubernetes/core
 msrest==0.7.1 # azure/azcollection
 msrestazure==0.6.4 # azure/azcollection
-ncclient>=0.6.3 # ansible/netcommon
-netaddr==0.7.19 # ansible/netcommon, ansible/utils
+ncclient # ansible/netcommon
+netaddr # ansible/netcommon, ansible/utils
 openstacksdk>=0.36,<0.99.0 # openstack/cloud
 ovirt-engine-sdk-python>=4.5.0 # ovirt/ovirt
 ovirt-imageio # ovirt/ovirt
 packaging # azure/azcollection
-paramiko==2.8.1 # ansible/netcommon
+paramiko>=2.9.3 # ansible/netcommon
 pexpect # legacy
 protobuf # ansible/netcommon
 psutil # legacy


### PR DESCRIPTION
## Code changes

- requirements.rb upgraded to take system packages into account

## Requirements changes

- google auth does not need to be pegged, opening up
- json schema upgraded for security reasons #476
- netaddr does not need to be pegged, opening up
- ncclient - opening up
- paramiko - added minimum for security reasons #272
- pyvmomi kept changed minimum version to support json
- azure-identity - changed minimum for security reasons (see note below) #507

NOTE:

Azure `requirements-azure.txt` pegs versions.
Loosened it up to resolve a security vulnerability on azure-identity
But when we run requirements.rb in the future, we will see the conflict.

```
azure-identity: >=1.16.0 > ==1.7.0 CONFLICT
```

## Outstanding

We may want to make a sweep later to determine whether we want to migrate some of these `pip` packages over to `rpm` packages.

