### PR TITLE
System rpm updates for paramiko and zipp

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -50,7 +50,7 @@ azure-nspkg==2.0.0 # azure/azcollection
 azure-storage-blob==12.11.0 # azure/azcollection
 boto3>=1.18.0 # amazon/aws, community/aws
 botocore>=1.21.0 # amazon/aws, community/aws
-cryptography>=36.0.0 # cisco/intersight
+cryptography # cisco/intersight
 deprecation # legacy
 google-auth # google/cloud
 google-cloud-storage # google/cloud
@@ -67,11 +67,10 @@ openstacksdk>=0.36,<0.99.0 # openstack/cloud
 ovirt-engine-sdk-python>=4.5.0 # ovirt/ovirt
 ovirt-imageio # ovirt/ovirt
 packaging # azure/azcollection
-paramiko>=2.9.3 # ansible/netcommon
-pexpect # legacy
+paramiko # ansible/netcommon
 protobuf # ansible/netcommon
 psutil # legacy
-python-dateutil>=2.7.0 # awx/awx
+python-dateutil # awx/awx
 pytz # awx/awx
 pyvmomi>=6.7.1 # community/vmware
 pywinrm # legacy

--- a/rpm_spec/subpackages/manageiq-ansible-venv
+++ b/rpm_spec/subpackages/manageiq-ansible-venv
@@ -5,6 +5,10 @@ Summary: %{product_summary} Ansible Runner Virtual Environment
 
 Requires: ansible >= 1:7, ansible < 1:8
 Requires: python3-virtualenv
+# used by ansible-runner (pip installed)
+Requires: python3-importlib-metadata
+# used by azure, ncclient
+Requires: python3-paramiko
 AutoReqProv: no
 
 %description ansible-venv


### PR DESCRIPTION
Updated 2 python packages and cleaned some dependencies up:

- Converted paramiko to an rpm dependency https://github.com/ManageIQ/manageiq-rpm_build/issues/430
- Convert python3-importlib-metadata (and therefore zipp) to an rpm dependency https://github.com/ManageIQ/manageiq-rpm_build/issues/476
- Dropped pexpect dependency. It is required by ansible-runner and not by a Collection.
- Cryptography is installed by rpm. Dropping explicit version.
- Dateutil is installed by rpm. Dropping explicit version.
- New build should resolve setuptools https://github.com/ManageIQ/manageiq-rpm_build/issues/477

Second commit fixes script to auto check rpms and no longer state package dependencies