### PR TITLE
Fix performance issue of looking up rpms

### DIFF
--- a/bin/requirements.rb
+++ b/bin/requirements.rb
@@ -48,9 +48,9 @@ class ParseRequirements
 
   # These packages are installed via rpm
   def os_packages
-    # Leaving his as pure bash so we can run from the command line to fix issues.
+    # Leaving this as pure bash so we can run from the command line to fix issues.
     @os_packages ||=
-      `for pkg in $(rpm -qa | grep python3- | sort) ; do rpm -ql $pkg | awk  -F/ '/site-packages.*-info$/ { print $6 }' | sed 's/-[0-9].*//' | tr '_A-Z' '-a-z' | sort -u; done`.chomp.split
+      `rpm -ql $(rpm -qa | grep python3- | sort) | awk  -F/ '/site-packages.*-info$/ { print $6 }' | sed 's/-[0-9].*//' | tr '_A-Z' '-a-z' | sort -u`.chomp.split
   end
 
   def os_package_regex
@@ -111,7 +111,7 @@ class ParseRequirements
         next if lib.start_with?("git")
 
         # Defer to version requirements provided by rpm system packages.
-        ver = "" if lib.match?(/^(#{os_package_regex.to_s})($|\[)/)
+        ver = "" if lib.match?(/^(#{os_package_regex})($|\[)/)
 
         final[lib] ||= {}
         (final[lib][ver] ||= []) << mod


### PR DESCRIPTION
Thanks @Fryguy Something in your comment triggered this thought.

Resolves performance issue introduced in #509 when it looks up all python packages associated with the system rpms. (dropping an N+1 for the win)

```
time VERBOSE=true ./requirements.rb requirements.txt \
     /usr/lib/python3.9/site-packages/ansible_collections/ > new_requirements.txt
```

Before
------

```
real	0m5.443s
```

After
-----

```
real	0m0.778s
```

But it feels 20x faster