### PR TITLE
openssl-libs is already installed in newer UBI9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN ARCH=$(uname -m) && \
     dnf -y install \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
       https://rpm.manageiq.org/release/19-spassky/el9/noarch/manageiq-release-19.0-1.el9.noarch.rpm && \
-    dnf -y --disablerepo=ubi-9-baseos-rpms swap openssl-fips-provider openssl-libs && \
     dnf -y update && \
     dnf -y module enable ruby:3.3 && \
     dnf -y module enable nodejs:18 && \


### PR DESCRIPTION
Error:
```
Package openssl-libs-1:3.2.2-6.el9_5.x86_64 is already installed. Error:
 Problem: package openssl-libs-1:3.2.2-6.el9_5.x86_64 from @System requires openssl-fips-provider, but none of the providers can be installed
  - cannot install the best candidate for the job
  - conflicting requests
```