### PR TITLE
Clean hotfix directory before patching the srpm contents

### DIFF
--- a/lib/manageiq/rpm_build/build_hotfix.rb
+++ b/lib/manageiq/rpm_build/build_hotfix.rb
@@ -14,6 +14,7 @@ module ManageIQ
         where_am_i
 
         Dir.chdir(HOTFIX_DIR) do
+          clean_hotfix_directory
           unpack_srpm
           update_spec
           copy_patches
@@ -62,6 +63,11 @@ module ManageIQ
         spec_text.sub!(/%changelog\n/) { |match| "#{match}#{changelog_entry}" }
 
         File.write(rpm_spec, spec_text)
+      end
+
+      def clean_hotfix_directory
+        files = Dir.glob("*[!.src.rpm]")
+        FileUtils.rm_f(files, :verbose => true)
       end
 
       def unpack_srpm


### PR DESCRIPTION
For those of us who don't patch the srpm contents correctly the first or
even second time, we should do something like make clean before we extract
the srpm, patch things, and attempt to rpmbuild.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
