### PR TITLE
Fix issues where exitstatus could be nil

### DIFF
--- a/lib/manageiq/rpm_build/helper.rb
+++ b/lib/manageiq/rpm_build/helper.rb
@@ -11,13 +11,13 @@ module ManageIQ
 
       def shell_cmd(cmd, env = {})
         puts_shell_cmd(cmd, env)
-        exit $?.exitstatus unless system(env, cmd.to_s)
+        exit($?.exitstatus || 1) unless system(env, cmd.to_s)
       end
 
       def shell_cmd_in_venv(cmd, venv, env = {})
         puts_shell_cmd(cmd, env, "(venv)")
         cmd = "source #{venv.join("bin/activate")}; #{cmd}; deactivate"
-        exit $?.exitstatus unless system(env, cmd.to_s)
+        exit($?.exitstatus || 1) unless system(env, cmd.to_s)
       end
 
       def puts_shell_cmd(cmd, env, prefix = "")


### PR DESCRIPTION
In cases where the process did not exit properly, exitstatus could be nil. This, in turn, is being sent to exit, which causes

    in `exit': no implicit conversion from nil to integer (TypeError)

exception, instead of exiting as expected.

@jrafanie Please review.