### PR TITLE
[morphy] env is not defined in this version

### DIFF
--- a/lib/manageiq/rpm_build/helper.rb
+++ b/lib/manageiq/rpm_build/helper.rb
@@ -7,7 +7,7 @@ module ManageIQ
 
       def shell_cmd(cmd)
         puts "\n ---> #{cmd}".yellow.bold
-        exit($?.exitstatus || 1) unless system(env, cmd.to_s)
+        exit($?.exitstatus || 1) unless system(cmd.to_s)
       end
     end
   end


### PR DESCRIPTION
```
 ---> git clone --depth 1 -b morphy https://github.com/ManageIQ/manageiq-appliance.git manageiq-appliance
/build_scripts/lib/manageiq/rpm_build/helper.rb:10:in `shell_cmd': undefined local variable or method `env' for #<ManageIQ::RPMBuild::SetupSourceRepos:0x00000100200973a8> (NameError) Did you mean?  end
               END
	from /build_scripts/lib/manageiq/rpm_build/setup_source_repos.rb:57:in `git_clone'
	from /build_scripts/lib/manageiq/rpm_build/setup_source_repos.rb:38:in `block in setup_source_repo'
	from /build_scripts/lib/manageiq/rpm_build/setup_source_repos.rb:37:in `chdir'
	from /build_scripts/lib/manageiq/rpm_build/setup_source_repos.rb:37:in `setup_source_repo'
	from /build_scripts/lib/manageiq/rpm_build/setup_source_repos.rb:21:in `populate'
	from bin/build.rb:19:in `<main>'
```
introduced in b66f923