### PR TITLE
Set SECRET_KEY_BASE_DUMMY=1 for random value for build with rails 7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM registry.access.redhat.com/ubi9/ubi
 
 ENV TERM=xterm \
     APPLIANCE=true \
-    RAILS_USE_MEMORY_STORE=true
+    RAILS_USE_MEMORY_STORE=true \
+    SECRET_KEY_BASE_DUMMY=1
 
 # Force the sticky bit on /tmp - https://bugzilla.redhat.com/show_bug.cgi?id=2138434
 RUN chmod +t /tmp


### PR DESCRIPTION
See: https://www.github.com/rails/rails/pull/46760

Note, we don't yet have require_master_key set to true, so this should work for now.  We'll need to see if that changes when/if we add rails configuration options going forward.

```
irb(main):003:0> Rails.application.config.require_master_key
=> false
```

This should resolve the failures in the build_rpms github action since we moved to rails 7.1:
https://github.com/ManageIQ/manageiq-rpm_build/actions/runs/13447148636/job/37575122953

```
 ---> ManageIQ::RPMBuild::GenerateGemSet#link_git_gems

 ---> find "$GEM_HOME/specifications" -type l -xtype l -delete

 ---> RAILS_ENV=production bundle exec rake evm:compile_assets
rake aborted!
ArgumentError: Missing `secret_key_base` for 'production' environment, set this string with `bin/rails credentials:edit` (ArgumentError)

        raise ArgumentError, "Missing `secret_key_base` for '#{Rails.env}' environment, set this string with `bin/rails credentials:edit`"
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/root/BUILD/manageiq-gemset-19.0.0/gems/railties-7.1.5.1/lib/rails/application.rb:661:in `validate_secret_key_base'
/root/BUILD/manageiq-gemset-19.0.0/gems/railties-7.1.5.1/lib/rails/application.rb:483:in `secret_key_base'
/root/BUILD/manageiq-gemset-19.0.0/gems/railties-7.1.5.1/lib/rails/application.rb:199:in `block in message_verifiers'
/root/BUILD/manageiq-gemset-19.0.0/gems/activesupport-7.1.5.1/lib/active_support/message_verifiers.rb:132:in `build'
/root/BUILD/manageiq-gemset-19.0.0/gems/activesupport-7.1.5.1/lib/active_support/messages/rotation_coordinator.rb:85:in `block in build_with_rotations'
/root/BUILD/manageiq-gemset-19.0.0/gems/activesupport-7.1.5.1/lib/active_support/messages/rotation_coordinator.rb:85:in `map'
/root/BUILD/manageiq-gemset-19.0.0/gems/activesupport-7.1.5.1/lib/active_support/messages/rotation_coordinator.rb:85:in `build_with_rotations'
/root/BUILD/manageiq-gemset-19.0.0/gems/activesupport-7.1.5.1/lib/active_support/messages/rotation_coordinator.rb:19:in `[]'
/root/BUILD/manageiq-gemset-19.0.0/gems/railties-7.1.5.1/lib/rails/application.rb:223:in `message_verifier'
```

Note, I'm still seeing psych 5 errors in the build from this PR: https://github.com/ManageIQ/manageiq-rpm_build/pull/528
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
