### PR TITLE
Add libyaml-devel for psych 5+ broken in #528

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN ARCH=$(uname -m) && \
       libcurl-devel \
       libpq-devel \
       librdkafka \
+      libyaml-devel \
       libssh2-devel \
       libxml2-devel \
       libxslt-devel \


### PR DESCRIPTION
PR #528 upgraded psych to allow version 5 and https://github.com/ManageIQ/manageiq-rpm_build/blob/master/.github/workflows/build_rpms.yaml, was quietly printing the error below without failing the build.

See: https://www.github.com/ruby/psych/pull/541
and related solution in https://www.github.com/rails/rails-dev-box/pull/202

Note, build_rpms github action was still passing so why do we even need psych here?

Should something be failing the build or can we delete psych as a dependency?

This fixes the error below if we really need psych 5+:

```
Installing psych 5.2.3 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /root/.local/share/gem/ruby/gems/psych-5.2.3/ext/psych
/usr/bin/ruby -I/usr/share/rubygems extconf.rb
checking for pkg-config for yaml-0.1... not found
checking for yaml.h... no
yaml.h not found
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
