### PR TITLE
Exit the user entrypoint on non-zero exit code

### DIFF
--- a/container-assets/user-entrypoint.sh
+++ b/container-assets/user-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 export GEM_HOME=$(ruby -e 'puts Gem.user_dir')
 export PATH=$GEM_HOME/bin:$HOME/bin:$PATH
 


### PR DESCRIPTION
Previously, when bundle failed following #528, the script continued and finished the build.  It's unclear if the psych 5 error mattered because our build still finished but we probably want to fail builds and fix issues if the entrypoint script encounters non-zero exit codes.

Pull #546 fixed the psych 5 issue and describes the issue of the silent error.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
