### PR TITLE
Core now sets secret_key_base early for all rails processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi
 
 ENV TERM=xterm \
     APPLIANCE=true \
-    RAILS_USE_MEMORY_STORE=true \
-    SECRET_KEY_BASE_DUMMY=1
+    RAILS_USE_MEMORY_STORE=true
 
 # Force the sticky bit on /tmp - https://bugzilla.redhat.com/show_bug.cgi?id=2138434
 RUN chmod +t /tmp


### PR DESCRIPTION
See: https://github.com/ManageIQ/manageiq/pull/23351

We no longer need to do the change in #545 because it is set in core for all rails processes in the new pull request above.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
