### PR TITLE
Builds frequently fail at git clean with binding.cpp being the only warning

### DIFF
--- a/lib/manageiq/rpm_build/generate_core.rb
+++ b/lib/manageiq/rpm_build/generate_core.rb
@@ -59,6 +59,7 @@ module ManageIQ
           shell_cmd("yarn install") # TODO: Add --immutable once s390x doesn't change the checksums.
           shell_cmd("yarn run available-languages")
           shell_cmd("yarn run build")
+          shell_cmd("rm -rf node_modules/node-sass/src/binding.cpp") # HACK: This file frequently comes up with a "warning: could not lstat node_modules/node-sass/src/binding.cpp : No such file or directory" during git clean
           shell_cmd("git clean -xdf") # cleanup temp files
         end
       end


### PR DESCRIPTION
Remove the file before running git clean in an attempt to avoid this error

```
---> git clean -xdf
warning: could not lstat node_modules/node-sass/src/binding.cpp : No such file or directory
Removing .yarn/install-state.gz
Removing client/gettext/json/supported_languages.json Removing client/skin
Removing client/version/version.json
Removing node_modules/node-sass/src/sass_types
Removing node_modules/node-sass/src/callback_bridge.h Removing node_modules/node-sass/src/create_string.cpp Removing node_modules/node-sass/src/custom_function_bridge.h Removing node_modules/node-sass/src/sass_context_wrapper.h Removing node_modules/node-sass/src/custom_importer_bridge.h Removing node_modules/node-sass/src/libsass
...
```
