### PR TITLE
cockpit-ssh is not available in CentOS Stream 9

### DIFF
--- a/rpm_spec/subpackages/manageiq-appliance
+++ b/rpm_spec/subpackages/manageiq-appliance
@@ -56,7 +56,6 @@ Requires: yum-utils
 
 # External configuration
 Requires: cockpit
-Requires: cockpit-ssh
 Requires: cockpit-ws
 
 %description appliance


### PR DESCRIPTION
Builds are failing with something like:
```
7 124.1 Error: 
#7 124.1  Problem: package manageiq-appliance-19.0.0-20250225001914.el9.x86_64 from manageiq-19-spassky-nightly requires cockpit, but none of the providers can be installed
#7 124.1   - package cockpit-327-1.el9.x86_64 from baseos requires cockpit-system, but none of the providers can be installed
#7 124.1   - package cockpit-330-1.el9.x86_64 from baseos requires cockpit-system, but none of the providers can be installed
#7 124.1   - package cockpit-331-1.el9.x86_64 from baseos requires cockpit-system, but none of the providers can be installed
#7 124.1   - package cockpit-332-1.el9.x86_64 from baseos requires cockpit-system, but none of the providers can be installed
#7 124.1   - package cockpit-333-1.el9.x86_64 from baseos requires cockpit-system, but none of the providers can be installed
#7 124.1   - package cockpit-system-327-1.el9.noarch from baseos requires cockpit-bridge >= 327-1.el9, but none of the providers can be installed
#7 124.1   - package cockpit-system-330-1.el9.noarch from baseos requires cockpit-bridge >= 330-1.el9, but none of the providers can be installed
#7 124.1   - package cockpit-system-331-1.el9.noarch from baseos requires cockpit-bridge >= 331-1.el9, but none of the providers can be installed
#7 124.1   - package cockpit-system-332-1.el9.noarch from baseos requires cockpit-bridge >= 332-1.el9, but none of the providers can be installed
#7 124.1   - package cockpit-system-333-1.el9.noarch from baseos requires cockpit-bridge >= 333-1.el9, but none of the providers can be installed
#7 124.1   - cannot install both cockpit-bridge-323.1-1.el9_5.x86_64 from ubi-9-baseos-rpms and cockpit-bridge-327-1.el9.x86_64 from baseos
#7 124.1   - cannot install both cockpit-bridge-323.1-1.el9_5.x86_64 from ubi-9-baseos-rpms and cockpit-bridge-330-1.el9.x86_64 from baseos
#7 124.1   - cannot install both cockpit-bridge-323.1-1.el9_5.x86_64 from ubi-9-baseos-rpms and cockpit-bridge-331-1.el9.x86_64 from baseos
#7 124.1   - cannot install both cockpit-bridge-323.1-1.el9_5.x86_64 from ubi-9-baseos-rpms and cockpit-bridge-332-1.el9.x86_64 from baseos
#7 124.1   - cannot install both cockpit-bridge-323.1-1.el9_5.x86_64 from ubi-9-baseos-rpms and cockpit-bridge-333-1.el9.x86_64 from baseos
#7 124.1   - package manageiq-appliance-19.0.0-20250225001914.el9.x86_64 from manageiq-19-spassky-nightly requires cockpit-ssh, but none of the providers can be installed
#7 124.1   - cannot install the best candidate for the job
#7 124.1 (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```