### PR TITLE
Loosen psych dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'droplet_kit',    "~>3.7",    :require => false
 gem 'manageiq-style'
 gem 'more_core_extensions'
 gem 'optimist'
-gem 'psych',          "<5.2.4"
+gem 'psych',          "~>5.2"
 gem 'rake',           ">=12.3.3"
 gem 'term-ansicolor'
 


### PR DESCRIPTION
Renovate is trying to update to <5.2.5 in #561 since 5.2.4 was just released. I don't see any reason for us to be locked down a z-stream, it was last changed from <4 to <5.2.4 in #528
