### PR TITLE
[spassky] Switch to openssl from CentOS Stream since it's newer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN ARCH=$(uname -m) && \
     dnf -y install \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
       https://rpm.manageiq.org/release/19-spassky/el9/noarch/manageiq-release-19.0-1.el9.noarch.rpm && \
-    dnf config-manager --save --setopt=appstream.exclude=openssl* --setopt=baseos.exclude=openssl* && \
+    dnf -y --disablerepo=ubi-9-baseos-rpms swap openssl-fips-provider openssl-libs && \
     dnf -y update && \
     dnf -y module enable ruby:3.3 && \
     dnf -y module enable nodejs:18 && \


### PR DESCRIPTION
nodejs 20 requires a newer version of libcrypto.so.3 than is available in the UBI repo

Error:
Problem: package nodejs-1:20.19.1-1.module_el9+1223+a180c0b3.x86_64 from appstream requires libcrypto.so.3(OPENSSL_3.4.0)(64bit), but none of the providers can be installed

(cherry picked from commit e79480a09ff92307018aae55f04bbb1414d78f18)

On this branch it's showing up as:
```
Error: 
 Problem: package ruby-3.3.8-4.module_el9+1234+fda12214.x86_64 from appstream requires ruby-libs(x86-64) = 3.3.8-4.module_el9+1234+fda12214, but none of the providers can be installed
  - package ruby-devel-3.3.8-4.module_el9+1234+fda12214.x86_64 from appstream requires ruby(x86-64) = 3.3.8-4.module_el9+1234+fda12214, but none of the providers can be installed
  - package ruby-libs-3.3.8-4.module_el9+1234+fda12214.x86_64 from appstream requires libcrypto.so.3(OPENSSL_3.4.0)(64bit), but none of the providers can be installed
  - cannot install the best candidate for the job
  - package openssl-libs-1:3.5.0-1.el9.x86_64 from baseos is filtered out by exclude filtering
  - package openssl-libs-1:3.5.0-2.el9.x86_64 from baseos is filtered out by exclude filtering
```