### PR TITLE
Drop dependencies that are now properly required by rails

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -4,9 +4,6 @@ Summary:  %{product_summary} Core
 Requires: ruby >= 3.3
 # Include weak dependencies of Ruby that we actually need
 Requires: ruby-default-gems
-Requires: rubygem-bigdecimal
-Requires: rubygem-io-console
-Requires: rubygem-irb
 
 Requires: %{name}-gemset = %{version}-%{release}
 Requires: %{name}-ansible-venv = %{version}-%{release}


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq/pull/23465#issuecomment-2917489057
