### PR TITLE
Update protobuf CVE-2025-4565

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -67,7 +67,7 @@ ovirt-engine-sdk-python>=4.5.0 # ovirt/ovirt
 ovirt-imageio # ovirt/ovirt
 packaging # azure/azcollection
 paramiko # ansible/netcommon
-protobuf # ansible/netcommon
+protobuf>=6.32 # ansible/netcommon
 python-dateutil>=2.7.0 # awx/awx
 pytz # awx/awx
 pyvmomi>=8.0.3.0.1 # community/vmware


### PR DESCRIPTION
Waiting on 3.2 released at https://pypi.org/project/protobuf/#history

currently CVE-2025-4565

looks like cryptography(rpm) is still an issue. 

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
