### PR TITLE
Update weak deps of ruby to include rubygems

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -1,9 +1,11 @@
+%global ruby_min_version 3.3
+
 %package core
 Summary:  %{product_summary} Core
 
-Requires: ruby >= 3.3
+Requires: ruby >= %{ruby_min_version}
 # Include weak dependencies of Ruby that we actually need
-Requires: ruby-default-gems
+Requires: ruby-default-gems >= %{ruby_min_version}
 Requires: rubygems
 
 Requires: %{name}-gemset = %{version}-%{release}


### PR DESCRIPTION
rubygems is now a weak dependency so we do need to include it

@bdunne Please review.