### PR TITLE
Remove unused .yarn and .github dirs from git-based gems

### DIFF
--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -177,6 +177,10 @@ module ManageIQ
           # Remove Gemfile.lock files shipped by gems.  They are not a problem, but flagged by some scanners and they shouldn't be shipped with gems anyway
           FileUtils.rm_rf(Dir.glob("gems/*/Gemfile.lock"))
 
+          # Remove unused .yarn and .github dirs from git-based gems
+          FileUtils.rm_rf(Dir.glob("bundler/gems/**/.github"))
+          FileUtils.rm_rf(Dir.glob("bundler/gems/**/.yarn"))
+
           ["gems", "bundler/gems"].each do |path|
             FileUtils.rm_rf(Dir.glob("#{path}/**/*.o"))
             FileUtils.rm_rf(Dir.glob("#{path}/*/docs"))


### PR DESCRIPTION
@bdunne Please review. Each .yarn directory is about 3MB, so this drops about 24MB from the final prod build.

Part of https://github.com/ManageIQ/manageiq-pods/issues/736