### PR TITLE
Split the RPM build and the RPM repo metadata update

### DIFF
--- a/.github/workflows/build_rpms.yaml
+++ b/.github/workflows/build_rpms.yaml
@@ -23,6 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "3.3"
+        bundler-cache: true
+      timeout-minutes: 30
     - name: Set up registry credentials
       run: |
         echo "REGISTRY_USERNAME=${{ secrets.DOCKER_REGISTRY_USERNAME }}" >> $GITHUB_ENV
@@ -38,6 +44,14 @@ jobs:
         echo "    secret_key: ${{ secrets.RPM_BUILD_S3_SECRET_KEY }}" >> /tmp/options/options.yml
     - name: Build and push RPMs
       run: bin/run_container_image
+    - name: Purge nightly RPMs
+      env:
+        OPTIONS_DIR: "/tmp"
+      run: bin/purge_nightly_rpms.rb
+    - name: Update RPM repo
+      env:
+        OPTIONS_DIR: "/tmp"
+      run: bin/update_rpm_repo.rb
   notify_builders:
     needs: build_rpms
     if: github.repository_owner == 'ManageIQ'

--- a/bin/build.rb
+++ b/bin/build.rb
@@ -9,6 +9,7 @@ opts = Optimist.options do
   opt :build_type,      "nightly or release", :type => :string, :default => "nightly"
   opt :git_ref,         "Git ref to use (default: git_ref specified in options.yml)", :type => :string, :default => ManageIQ::RPMBuild::OPTIONS.repos.ref
   opt :update_rpm_repo, "Publish the resulting RPMs to the public repository?"
+  opt :upload,          "Push the resulting RPMs to the builds directory?"
 end
 Optimist.die "build type must be either nightly or release" unless %w[nightly release].include?(opts[:build_type])
 
@@ -50,8 +51,11 @@ puts "\n\nTARBALL BUILT SUCCESSFULLY"
 release_name = build_type == "release" ? git_ref : ""
 ManageIQ::RPMBuild::BuildCopr.new(release_name).generate_rpm
 
-if opts[:update_rpm_repo]
+if opts[:upload]
   ManageIQ::RPMBuild::BuildUploader.new(:release => build_type == "release").upload
+end
+
+if opts[:update_rpm_repo]
   ManageIQ::RPMBuild::NightlyBuildPurger.new.run
   ManageIQ::RPMBuild::RpmRepo.new.update
 end

--- a/bin/purge_nightly_rpms.rb
+++ b/bin/purge_nightly_rpms.rb
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+
+require 'manageiq-rpm_build'
+
+ManageIQ::RPMBuild::NightlyBuildPurger.new.run

--- a/bin/run_container_image
+++ b/bin/run_container_image
@@ -13,6 +13,6 @@ set -e
 
 echo "$REGISTRY_PASSWORD" | docker login $REGISTRY -u $REGISTRY_USERNAME --password-stdin
 
-docker run -v /tmp/options:/root/OPTIONS:z $IMAGE_NAME build --build-type nightly --git-ref $GITHUB_REF_NAME --update-rpm-repo
+docker run --rm -v /tmp/options:/root/OPTIONS:z $IMAGE_NAME build --build-type nightly --git-ref $GITHUB_REF_NAME --upload
 
 set +e

--- a/bin/update_rpm_repo.rb
+++ b/bin/update_rpm_repo.rb
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+
+require 'manageiq-rpm_build'
+
+ManageIQ::RPMBuild::RpmRepo.new.update


### PR DESCRIPTION
- Ensure we are deleting the build container after it runs and uploads the RPMs
- The RPM repo update does not require the container and can be run directly with the system ruby.

If I run the update_rpm_repo.rb script locally, the downloaded content is just over 5GB, so that alone shouldn't run out of disk space.  We're probably running out of space because we have all of the other files generated by the RPM build itself inside the container.

Fixes: https://github.com/ManageIQ/manageiq-rpm_build/issues/599
