### PR TITLE
[spassky] lockdown bundler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,6 @@ RUN curl -o /usr/lib/rpm/brp-strip https://raw.githubusercontent.com/rpm-softwar
   cd /usr/lib/rpm/ && \
   patch -p2 < /build_scripts/container-assets/Add-js-rb-filtering-on-top-of-4.19.1.patch
 
-RUN gem install bundler
+RUN gem install bundler -v 2.7.2
 
 ENTRYPOINT ["/build_scripts/container-assets/user-entrypoint.sh"]

--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -71,7 +71,7 @@ module ManageIQ
           lock_release = miq_dir.join("Gemfile.lock.release")
           if lock_release.exist?
             FileUtils.ln_s(lock_release, "Gemfile.lock", :force => true)
-            shell_cmd("bundle lock --update --conservative --patch") if build_type == "nightly"
+            shell_cmd("bundle _2.7.2_ lock --update --conservative --patch") if build_type == "nightly"
           end
 
           shell_cmd("bundle install --redownload --jobs #{cpus} --retry 3")


### PR DESCRIPTION
Lock down bundler to v2.7.2 to prevent attempts to use bundler 4 which is incompatible with the restrictions in the main Gemfile.