### PR TITLE
Run license finder before scrubbing to avoid issues with missing .yarn

### DIFF
--- a/bin/build.rb
+++ b/bin/build.rb
@@ -32,14 +32,15 @@ gemset.populate_gem_home(build_type)
 # Generate 'core' contents
 ManageIQ::RPMBuild::GenerateCore.new.populate
 
+# Generate manifest with license info for gems and npm packages
+gemset.generate_dependency_manifest
+
 # Scrub the gemset only after it is used to generate 'core' contents
 gemset.scrub
 
 # Create tarballs
 ManageIQ::RPMBuild::GenerateTarFiles.new.create_tarballs
 
-# Generate manifest with license info for gems and npm packages
-gemset.generate_dependency_manifest
 gemset.restore_environment_variables
 
 # Create manifest tarball


### PR DESCRIPTION
Error:
```
LicenseFinder::NPM: is active
LicenseFinder::Yarn: is active
.../gems/license_finder-7.0.1/lib/license_finder/package_managers/yarn.rb:90:in `block in yarn_version': Command 'yarn -v' failed to execute: node:internal/modules/cjs/loader:1210 (RuntimeError)
  throw err;
  ^

Error: Cannot find module '...../.yarn/releases/yarn-4.12.0.cjs'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1207:15)
    at Module._load (node:internal/modules/cjs/loader:1038:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:164:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
```

CP4AIOPS-23665