### PR TITLE
Drop migration of old service names

### DIFF
--- a/rpm_spec/subpackages/manageiq-core-services
+++ b/rpm_spec/subpackages/manageiq-core-services
@@ -6,21 +6,11 @@ Requires: %{name}-core = %{version}-%{release}
 %description core-services
 %{product_summary} Core Services
 
-%post core-services
-# Remove any old dynamic systemd unit files prior to the switch to static systemd unit files - See ManageIQ/manageiq#20983
-files="remote_console cockpit_ws priority reporting generic event_handler ems_metrics_processor smart_proxy web_service schedule ui"
-for file in ${files}
-do
-  if [[ -e /etc/systemd/system/${file}.target ]]; then rm -f /etc/systemd/system/${file}.target; fi
-  if [[ -e /etc/systemd/system/${file}@.service ]]; then rm -f /etc/systemd/system/${file}@.service; fi
-  if [[ -e /etc/systemd/system/${file}@*.service ]]; then rm -f /etc/systemd/system/${file}@*.service; fi
-  if [[ -e /etc/systemd/system/${file}@*.service.d/override.conf ]]; then rm -f /etc/systemd/system/${file}@*.service.d/override.conf; fi
-  if [[ -e /etc/systemd/system/${file}@*.service.d ]]; then rm -rf /etc/systemd/system/${file}@*.service.d; fi
-done
-
 %files core-services
 %{_prefix}/lib/systemd/system/manageiq*
+# Provided by the manageiq-appliance subpackage
 %exclude %{_prefix}/lib/systemd/system/manageiq-db-ready.service
 %exclude %{_prefix}/lib/systemd/system/manageiq-messaging-ready.service
 %exclude %{_prefix}/lib/systemd/system/manageiq-podman-cleanup.service
+# Provided by the manageiq-gemset-services subpackage
 %exclude %{_prefix}/lib/systemd/system/manageiq-providers*

--- a/rpm_spec/subpackages/manageiq-gemset-services
+++ b/rpm_spec/subpackages/manageiq-gemset-services
@@ -6,30 +6,6 @@ Requires: %{name}-gemset = %{version}-%{release}
 %description gemset-services
 %{product_summary} Gemset Services
 
-%post gemset-services
-# Remove any old dynamic systemd unit files prior to the switch to static systemd unit files - See ManageIQ/manageiq#20983
-provider_worker_types="event_catcher metrics_collector refresh operations"
-provider_types="amazon_cloud_manager ansible_tower_automation_manager azure_cloud_manager autosde_storage_manager azure_stack_cloud_manager azure_stack_network_manager foreman_configuration_manager google_cloud_manager google_network_manager ibm_cloud_vpc_cloud_manager ibm_cloud_power_virtual_servers_cloud_manager ibm_terraform_configuration_manager kubernetes_container_manager kubernetes_monitoring_manager kubevirt_infra_manager lenovo_physical_infra_manager microsoft_infra_manager nsxt_network_manager nuage_network_manager openshift_container_manager openshift_monitoring_manager openstack_cloud_manager openstack_infra_manager openstack_network_manager openstack_storage_manager_cinder_manager amazon_storage_manager_s3 redhat_infra_manager redhat_network_manager redfish_physical_infra_manager vmware_cloud_manager vmware_infra_manager"
-
-files=""
-for provider_type in ${provider_types}
-do
-  for provider_worker_type in ${provider_worker_types}
-  do
-    files+="${provider_type}_${provider_worker_type} "
-  done
-done
-files+="amazon_agent_coordinator"
-
-for file in ${files}
-do
-  if [[ -e /etc/systemd/system/${file}.target ]]; then rm -f /etc/systemd/system/${file}.target; fi
-  if [[ -e /etc/systemd/system/${file}@.service ]]; then rm -f /etc/systemd/system/${file}@.service; fi
-  if [[ -e /etc/systemd/system/${file}@*.service ]]; then rm -f /etc/systemd/system/${file}@*.service; fi
-  if [[ -e /etc/systemd/system/${file}@*.service.d/override.conf ]]; then rm -f /etc/systemd/system/${file}@*.service.d/override.conf; fi
-  if [[ -e /etc/systemd/system/${file}@*.service.d ]]; then rm -rf /etc/systemd/system/${file}@*.service.d; fi
-done
-
 %files gemset-services
 %{_prefix}/lib/systemd/system/manageiq-providers*
 %{_prefix}/lib/systemd/system/opentofu-runner*


### PR DESCRIPTION
These migrations were added to support the change from dynamic to static service names in ManageIQ/manageiq#20983. That PR was released in Najdorf, and since then we've had a forced interim upgrade step in order to deal with EL9 upgrade. As such, we don't need this migration code anymore.

@agrare Please review.