### PR TITLE
Add bundler/setup to scripts run in CI

### DIFF
--- a/bin/purge_nightly_rpms.rb
+++ b/bin/purge_nightly_rpms.rb
@@ -2,6 +2,7 @@
 
 $LOAD_PATH << File.expand_path("../lib", __dir__)
 
+require 'bundler/setup'
 require 'manageiq-rpm_build'
 
 ManageIQ::RPMBuild::NightlyBuildPurger.new.run

--- a/bin/update_rpm_repo.rb
+++ b/bin/update_rpm_repo.rb
@@ -2,6 +2,7 @@
 
 $LOAD_PATH << File.expand_path("../lib", __dir__)
 
+require 'bundler/setup'
 require 'manageiq-rpm_build'
 
 ManageIQ::RPMBuild::RpmRepo.new.update


### PR DESCRIPTION
Should fix errors where the bundled gems are not found.

```
Run bin/purge_nightly_rpms.rb
<internal:/opt/hostedtoolcache/Ruby/3.3.10/x64/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require': cannot load such file -- config (LoadError)
Did you mean?  rbconfig
	from <internal:/opt/hostedtoolcache/Ruby/3.3.10/x64/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
	from /home/runner/work/manageiq-rpm_build/manageiq-rpm_build/lib/manageiq/rpm_build.rb:1:in `<top (required)>'
	from <internal:/opt/hostedtoolcache/Ruby/3.3.10/x64/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
	from <internal:/opt/hostedtoolcache/Ruby/3.3.10/x64/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
	from /home/runner/work/manageiq-rpm_build/manageiq-rpm_build/lib/manageiq-rpm_build.rb:1:in `<top (required)>'
	from <internal:/opt/hostedtoolcache/Ruby/3.3.10/x64/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
	from <internal:/opt/hostedtoolcache/Ruby/3.3.10/x64/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
	from bin/purge_nightly_rpms.rb:5:in `<main>'
```

@bdunne Please review. Alternatively, I could change the github workflow to call `bundle exec` for the scripts. Up to you.