### PR TITLE
Workaround for s390x builds

### DIFF
--- a/packages/Dockerfile
+++ b/packages/Dockerfile
@@ -3,4 +3,5 @@ FROM registry.fedoraproject.org/fedora:43
 
 WORKDIR /work
 
-RUN dnf -y install git mock
+RUN dnf -y install git mock && \
+    usermod -a -G mock root  # Add root to the mock group because s390x builds are failing AppArmor when calling PAM


### PR DESCRIPTION
"The build fails because mock ends up triggering PAM, PAM calls unix_chkpwd and AppArmor denies unix_chkpwd when it touches files via Docker overlay paths inside LXD."

https://github.com/IBM/actionspz/issues/78

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
