### PR TITLE
Ensure that we install the correct version of bundler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,4 @@ RUN curl -o /usr/lib/rpm/brp-strip https://raw.githubusercontent.com/rpm-softwar
   cd /usr/lib/rpm/ && \
   patch -p2 < /build_scripts/container-assets/Add-js-rb-filtering-on-top-of-4.19.1.patch
 
-RUN gem install bundler
-
 ENTRYPOINT ["/build_scripts/container-assets/user-entrypoint.sh"]

--- a/lib/manageiq/rpm_build/generate_gemset.rb
+++ b/lib/manageiq/rpm_build/generate_gemset.rb
@@ -48,8 +48,6 @@ module ManageIQ
       def recreate_gem_home
         FileUtils.rm_rf(GEM_HOME) if GEM_HOME.exist?
         FileUtils.mkdir(GEM_HOME)
-        cmd = "gem install bundler:#{`bundle -v`.chomp.split(" ").last}"
-        shell_cmd(cmd)
       end
 
       def populate_gem_home(build_type)
@@ -57,6 +55,13 @@ module ManageIQ
 
         Dir.chdir(miq_dir) do
           shell_cmd("gem env")
+
+          lock_release = miq_dir.join("Gemfile.lock.release")
+          FileUtils.cp(lock_release, "Gemfile.lock") if lock_release.exist?
+
+          bundler_version = lock_release.readlines.last.strip if lock_release.exist?
+          bundler_version ||= `bundle -v`.chomp.split(" ").last
+          shell_cmd("gem install bundler:#{bundler_version}")
 
           if RUBY_PLATFORM.match?(/powerpc64le|s390x/)
             shell_cmd("bundle config set build.sassc --disable-march-tune-native")
@@ -66,13 +71,9 @@ module ManageIQ
           shell_cmd("bundle config set --local build.rugged --with-ssh")
           shell_cmd("bundle config set --local with appliance qpid_proton systemd")
           shell_cmd("bundle config set --local without development test")
-          shell_cmd("bundle config")
+          shell_cmd("bundle env")
 
-          lock_release = miq_dir.join("Gemfile.lock.release")
-          if lock_release.exist?
-            FileUtils.ln_s(lock_release, "Gemfile.lock", :force => true)
-            shell_cmd("bundle lock --update --conservative --patch") if build_type == "nightly"
-          end
+          shell_cmd("bundle lock --update --conservative --patch") if build_type == "nightly" && lock_release.exist?
 
           shell_cmd("bundle install --redownload --jobs #{cpus} --retry 3")
 


### PR DESCRIPTION
We want the version that was used to build the manageiq lockfile.

Error with latest bundler (v4):
```
     ---> bundle lock --update --conservative --patch
    Writing lockfile to /root/BUILD/manageiq/Gemfile.lock
    Fetching https://github.com/ManageIQ/manageiq-schema
    Fetching https://github.com/ManageIQ/manageiq-gems-pending.git
    Fetching https://github.com/ManageIQ/manageiq-providers-amazon
    Fetching https://github.com/ManageIQ/manageiq-providers-nuage
    Fetching https://github.com/ManageIQ/manageiq-providers-openstack
    Fetching https://github.com/ManageIQ/manageiq-providers-azure
    Fetching https://github.com/ManageIQ/manageiq-providers-vmware
    Fetching https://github.com/ManageIQ/manageiq-providers-ansible_tower
    Fetching https://github.com/ManageIQ/manageiq-providers-autosde
    Fetching https://github.com/ManageIQ/manageiq-ui-classic
    Fetching https://github.com/ManageIQ/manageiq-providers-workflows
    Fetching https://github.com/ManageIQ/manageiq-providers-embedded_terraform
    Fetching https://github.com/ManageIQ/manageiq-providers-google
    Fetching https://github.com/ManageIQ/manageiq-providers-foreman
    Fetching https://github.com/ManageIQ/manageiq-consumption
    Fetching https://github.com/ManageIQ/manageiq-providers-ibm_cloud
    Fetching https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc
    Fetching https://github.com/ManageIQ/manageiq-providers-kubernetes
    Fetching https://github.com/ManageIQ/manageiq-providers-cisco_intersight
    Fetching https://github.com/ManageIQ/manageiq-api
    Fetching https://github.com/ManageIQ/manageiq-providers-kubevirt
    Fetching https://github.com/ManageIQ/manageiq-automation_engine
    Fetching https://github.com/ManageIQ/manageiq-content
    Fetching https://github.com/ManageIQ/manageiq-providers-lenovo
    Fetching https://github.com/ManageIQ/manageiq-providers-nutanix
    Fetching https://github.com/ManageIQ/manageiq-providers-oracle_cloud
    Fetching https://github.com/ManageIQ/manageiq-providers-ovirt
    Fetching https://github.com/ManageIQ/manageiq-providers-proxmox
    Fetching https://github.com/ManageIQ/manageiq-providers-redfish
    Fetching https://github.com/ManageIQ/manageiq-decorators
    Fetching https://github.com/ManageIQ/manageiq-providers-openshift
    Fetching https://github.com/ManageIQ/manageiq-providers-terraform_enterprise
    Fetching https://github.com/ManageIQ/manageiq-providers-red_hat_virtualization
    Fetching https://github.com/ManageIQ/manageiq-providers-nsxt
    Fetching https://github.com/ManageIQ/manageiq-providers-ibm_terraform
    Fetching https://github.com/ManageIQ/manageiq-providers-ibm_power_vc
    Fetching https://github.com/ManageIQ/manageiq-providers-ibm_cic
    Fetching https://github.com/ManageIQ/manageiq-providers-azure_stack
    Fetching https://github.com/ManageIQ/manageiq-providers-awx
    Fetching https://github.com/ManageIQ/amazon_ssa_support.git
    Fetching source index from https://rubygems.manageiq.org/
    Fetching gem metadata from https://rubygems.org/......
    Fetching source index from https://rubygems.org/
    Resolving dependencies...
    Git error: command `git rev-parse --verify tal` in directory /root/BUILD/manageiq-gemset-20.0.0/cache/bundler/git/manageiq-api-ace8244e46608adbf2d3e251a79e28adb9add9a6 has failed.
    Revision tal does not exist in the repository https://github.com/ManageIQ/manageiq-api. Maybe you misspelled it?
```