### PR TITLE
Fix restorecon clearing valid selinux labels

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -71,7 +71,6 @@ semanage fcontext --add --type container_ro_file_t '%{manageiq_var_lib_root}/con
 semanage fcontext --add --type container_ro_file_t '%{manageiq_var_lib_root}/containers/storage/artifacts(/.*)?'
 semanage fcontext --add --type container_file_t    '%{manageiq_var_lib_root}/containers/storage/volumes/[^/]*/.*'
 semanage fcontext --add --type container_var_lib_t '%{manageiq_var_lib_root}/containers(/.*)?'
-restorecon -RvF %{manageiq_var_lib_root}/containers/
 
 %files core
 %defattr(-,root,root,-)


### PR DESCRIPTION
If there are files in `/var/lib/manageiq/containers/storage` when running the rpm install then the selinux context of the subdirectories gets wiped out.

Since we're creating this directory it should be empty and there should be no need to run restorecon.  Once the directory is created all files will have proper contexts anyway and relabeling also not necessary.

This fixes any existing files in `/var/lib/manageiq/containers/storage` having the `container_var_lib_t` context after running the rpm install.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
