### PR TITLE
Set SELinux context non-recursively for manageiq containers/storage

### DIFF
--- a/rpm_spec/subpackages/manageiq-core
+++ b/rpm_spec/subpackages/manageiq-core
@@ -72,6 +72,9 @@ semanage fcontext --add --type container_ro_file_t '%{manageiq_var_lib_root}/con
 semanage fcontext --add --type container_file_t    '%{manageiq_var_lib_root}/containers/storage/volumes/[^/]*/.*'
 semanage fcontext --add --type container_var_lib_t '%{manageiq_var_lib_root}/containers(/.*)?'
 
+restorecon %{manageiq_var_lib_root}/containers/
+restorecon %{manageiq_var_lib_root}/containers/storage/
+
 %files core
 %defattr(-,root,root,-)
 %{app_root}


### PR DESCRIPTION
Ensure that the manageiq containers/storage directory get the proper selinux context after it is created.  Don't run restorecon recursively which was an issue previously, only on these two folders which get created if they are missing.

I realized a flaw in my testing of the first case here https://github.com/ManageIQ/manageiq-rpm_build/pull/627#issuecomment-4040458898 where I deleted the directory so it had to be created, but I didn't account for the selinux contexts already existing from the existing installation.

To test this I deleted the containers/storage dir and also all of the selinux contexts:
```
rm -rf /var/lib/manageiq/containers
for f in `semanage fcontext --list | grep 'var/lib/manageiq' | awk '{print $1}'`; do echo $f; semanage fcontext --delete $f; done
```

This would occur if someone upgrades across multiple versions from when this directory didn't exist.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
