### PR TITLE
[WIP] Upgrade kafka to 3.9.1 and changes for EL10

### DIFF
--- a/packages/kafka/0001-move_config_to_etc.patch
+++ b/packages/kafka/0001-move_config_to_etc.patch
@@ -1,0 +1,123 @@
+diff --git a/bin/connect-distributed.sh b/bin/connect-distributed.sh
+index b8088ad..61469be 100755
+--- a/bin/connect-distributed.sh
++++ b/bin/connect-distributed.sh
+@@ -23,7 +23,7 @@ fi
+ base_dir=$(dirname $0)
+ 
+ if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
+-    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/connect-log4j.properties"
++    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:/etc/kafka/config/connect-log4j.properties"
+ fi
+ 
+ if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
+diff --git a/bin/connect-mirror-maker.sh b/bin/connect-mirror-maker.sh
+index 8e2b2e1..ad1b0c2 100755
+--- a/bin/connect-mirror-maker.sh
++++ b/bin/connect-mirror-maker.sh
+@@ -23,7 +23,7 @@ fi
+ base_dir=$(dirname $0)
+ 
+ if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
+-    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/connect-log4j.properties"
++    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:/etc/kafka/config/connect-log4j.properties"
+ fi
+ 
+ if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
+diff --git a/bin/connect-standalone.sh b/bin/connect-standalone.sh
+index bef78d6..b71baa6 100755
+--- a/bin/connect-standalone.sh
++++ b/bin/connect-standalone.sh
+@@ -23,7 +23,7 @@ fi
+ base_dir=$(dirname $0)
+ 
+ if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
+-    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/connect-log4j.properties"
++    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:/etc/kafka/config/connect-log4j.properties"
+ fi
+ 
+ if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
+diff --git a/bin/kafka-run-class.sh b/bin/kafka-run-class.sh
+index b3291e4..63d8080 100755
+--- a/bin/kafka-run-class.sh
++++ b/bin/kafka-run-class.sh
+@@ -228,7 +228,7 @@ fi
+ # Log4j settings
+ if [ -z "$KAFKA_LOG4J_OPTS" ]; then
+   # Log to console. This is a tool.
+-  LOG4J_DIR="$base_dir/config/tools-log4j.properties"
++  LOG4J_DIR="/etc/kafka/config/tools-log4j.properties"
+   # If Cygwin is detected, LOG4J_DIR is converted to Windows format.
+   (( WINDOWS_OS_FORMAT )) && LOG4J_DIR=$(cygpath --path --mixed "${LOG4J_DIR}")
+   KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:${LOG4J_DIR}"
+diff --git a/bin/kafka-server-start.sh b/bin/kafka-server-start.sh
+index 5a53126..d894be2 100755
+--- a/bin/kafka-server-start.sh
++++ b/bin/kafka-server-start.sh
+@@ -22,7 +22,7 @@ fi
+ base_dir=$(dirname $0)
+ 
+ if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
+-    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"
++    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:/etc/kafka/config/log4j.properties"
+ fi
+ 
+ if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
+diff --git a/bin/zookeeper-server-start.sh b/bin/zookeeper-server-start.sh
+index bd9c114..c04195f 100755
+--- a/bin/zookeeper-server-start.sh
++++ b/bin/zookeeper-server-start.sh
+@@ -22,13 +22,15 @@ fi
+ base_dir=$(dirname $0)
+ 
+ if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
+-    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"
++    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:/etc/kafka/config/log4j.properties"
+ fi
+ 
+ if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
+     export KAFKA_HEAP_OPTS="-Xmx512M -Xms512M"
+ fi
+ 
++export LOG_DIR="/var/log/zookeeper"
++
+ EXTRA_ARGS=${EXTRA_ARGS-'-name zookeeper -loggc'}
+ 
+ COMMAND=$1
+diff --git a/config/server.properties b/config/server.properties
+index 21ba1c7..953ccc7 100644
+--- a/config/server.properties
++++ b/config/server.properties
+@@ -59,7 +59,7 @@ socket.request.max.bytes=104857600
+ ############################# Log Basics #############################
+ 
+ # A comma separated list of directories under which to store log files
+-log.dirs=/tmp/kafka-logs
++log.dirs=/var/lib/kafka
+ 
+ # The default number of log partitions per topic. More partitions allow greater
+ # parallelism for consumption, but this will also result in more files across
+diff --git a/config/zookeeper.properties b/config/zookeeper.properties
+index 90f4332..826964b 100644
+--- a/config/zookeeper.properties
++++ b/config/zookeeper.properties
+@@ -4,16 +4,16 @@
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License.  You may obtain a copy of the License at
+-# 
++#
+ #    http://www.apache.org/licenses/LICENSE-2.0
+-# 
++#
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ # the directory where the snapshot is stored.
+-dataDir=/tmp/zookeeper
++dataDir=/var/lib/zookeeper
+ # the port at which the clients will connect
+ clientPort=2181
+ # disable the per-ip limit on the number of connections since this is a non-production config

--- a/packages/kafka/kafka.service
+++ b/packages/kafka/kafka.service
@@ -3,9 +3,9 @@ Description=kafka service
 After=zookeeper.service
 
 [Service]
-Environment="KAFKA_OPTS=-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
+Environment="KAFKA_OPTS=-Djava.security.auth.login.config=/etc/kafka/config/kafka_server_jaas.conf"
 Environment="LOG_DIR=/var/log/kafka"
-ExecStart=/opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/server.properties
+ExecStart=/opt/kafka/bin/kafka-server-start.sh /etc/kafka/config/server.properties
 Restart=on-failure
 User=kafka
 Group=kafka

--- a/packages/kafka/kafka.spec
+++ b/packages/kafka/kafka.spec
@@ -1,28 +1,33 @@
 Name:             kafka
 Summary:          Apache Kafka is an open-source stream-processing software platform
-Version:          3.7.0
+Version:          3.9.1
 Release:          1%{?dist}
 License:          Apache (v2)
 Group:            Applications
 URL:              https://kafka.apache.org
-BuildRequires:    java-11-openjdk-devel
+BuildRequires:    git
+BuildRequires:    java-21-openjdk-devel
 BuildRequires:    systemd-rpm-macros
-Requires:         java-11-openjdk
+Requires:         java-21-openjdk-headless
 Requires(post):   systemd
 Requires(postun): systemd
 Requires(preun):  systemd
 Source0:          http://archive.apache.org/dist/%{name}/%{version}/%{name}-%{version}-src.tgz
 Source1:          kafka.service
 Source2:          zookeeper.service
+Source3:          kafka.sysusers
+Patch0:           0001-move_config_to_etc.patch
 Provides:         kafka
 BuildRoot:        %{_tmppath}/%{name}-%{version}-root
 
 
 %global debug_package %{nil}
 %define __jar_repack 0
+%define etc_kafka %{_sysconfdir}/kafka
 %define kafka_home /opt/kafka
 %define kafka_group %{name}
 %define kafka_user %{name}
+%{?sysusers_requires_compat}
 
 
 %description
@@ -30,12 +35,11 @@ Kafka® is used for building real-time data pipelines and streaming apps. It is 
 
 
 %pre
-groupadd -fr %{kafka_group}
-getent passwd %{kafka_user} >/dev/null || useradd -r -g %{kafka_group} -d %{_sharedstatedir}/kafka -s /sbin/nologin -c "User for kafka services" %{kafka_user}
+%sysusers_create_compat %{SOURCE3}
 
 
 %prep
-%setup -q -n %{name}-%{version}-src
+%autosetup -n %{name}-%{version}-src -S git
 
 
 %build
@@ -43,8 +47,10 @@ getent passwd %{kafka_user} >/dev/null || useradd -r -g %{kafka_group} -d %{_sha
 
 
 %install
+mkdir -p %{buildroot}%{etc_kafka}
+mkdir -p %{buildroot}%{etc_kafka}/config
+mkdir -p %{buildroot}%{etc_kafka}/keystore
 mkdir -p %{buildroot}%{kafka_home}
-mkdir -p %{buildroot}%{kafka_home}/config/keystore
 mkdir -p %{buildroot}%{kafka_home}/libs
 mkdir -p %{buildroot}%{_localstatedir}/log/kafka
 mkdir -p %{buildroot}%{_sharedstatedir}/kafka
@@ -55,30 +61,37 @@ rm -rf bin/windows
 cp LICENSE %{buildroot}%{kafka_home}
 cp NOTICE %{buildroot}%{kafka_home}
 cp -r bin %{buildroot}%{kafka_home}
-sed "s,log.dirs=.*,log.dirs=%{_sharedstatedir}/kafka," config/server.properties > %{buildroot}%{kafka_home}/config/server.properties
-sed "s,dataDir=.*,dataDir=%{_sharedstatedir}/zookeeper," config/zookeeper.properties > %{buildroot}%{kafka_home}/config/zookeeper.properties
-cp -r config %{buildroot}%{kafka_home}/config-sample
-cp config/log4j.properties %{buildroot}%{kafka_home}/config
-cp config/tools-log4j.properties %{buildroot}%{kafka_home}/config
+cp -r config %{buildroot}%{etc_kafka}/config-sample
+cp config/log4j.properties %{buildroot}%{etc_kafka}/config
+cp config/server.properties %{buildroot}%{etc_kafka}/config
+cp config/tools-log4j.properties %{buildroot}%{etc_kafka}/config
+cp config/zookeeper.properties %{buildroot}%{etc_kafka}/config
 cp -n */build/libs/* %{buildroot}%{kafka_home}/libs
 cp -n */build/dependant-libs*/* %{buildroot}%{kafka_home}/libs
 cp -n */*/build/libs/* %{buildroot}%{kafka_home}/libs
 cp -n */*/build/dependant-libs*/* %{buildroot}%{kafka_home}/libs
 
+
+#/builddir/build/BUILD/kafka-3.9.1-src
+
 # Install systemd units
 install -m755 -d %{buildroot}%{_unitdir}
 install -pm644 %SOURCE1 %SOURCE2 %{buildroot}%{_unitdir}/
 
+# Install the sysuser config file
+install -p -D -m 0644 %{SOURCE3} %{buildroot}%{_sysusersdir}/kafka.conf
 
 %files
 %defattr(-,root,root)
 %{_unitdir}/kafka.service
 %{_unitdir}/zookeeper.service
 %{kafka_home}
+%config %attr(-, %{kafka_user}, %{kafka_group}) %{etc_kafka}
 %config %attr(-, %{kafka_user}, %{kafka_group}) %{_sharedstatedir}/kafka
 %config %attr(-, %{kafka_user}, %{kafka_group}) %{_localstatedir}/log/kafka
 %config %attr(-, %{kafka_user}, %{kafka_group}) %{_sharedstatedir}/zookeeper
 %config %attr(-, %{kafka_user}, %{kafka_group}) %{_localstatedir}/log/zookeeper
+%{_sysusersdir}/kafka.conf
 
 
 %post
@@ -101,6 +114,11 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Thu Apr 2 2026 "Brandon Dunne" <brandondunne@hotmail.com> - 3.9.1-1
+- Upgrade to v3.9.1
+- Changes for EL10 bootc
+- Switch to sysuser config file for user and group creation
+
 * Wed Feb 28 2024 "Brandon Dunne" <brandondunne@hotmail.com> - 3.7.0-1
 - Upgrade to 3.7.0
 

--- a/packages/kafka/kafka.sysusers
+++ b/packages/kafka/kafka.sysusers
@@ -1,0 +1,2 @@
+g kafka 902
+u kafka 902 "Kafka" /var/lib/kafka /sbin/nologin

--- a/packages/kafka/zookeeper.service
+++ b/packages/kafka/zookeeper.service
@@ -3,7 +3,7 @@ Description=zookeeper service
 After=network.target
 
 [Service]
-ExecStart=/opt/kafka/bin/zookeeper-server-start.sh /opt/kafka/config/zookeeper.properties
+ExecStart=/opt/kafka/bin/zookeeper-server-start.sh /etc/kafka/config/zookeeper.properties
 Restart=on-failure
 User=kafka
 Group=kafka


### PR DESCRIPTION
- Use Systemd sysusers rather than custom logic for creating the kafka user and group and set a static UID to avoid future upgrade issues.
- Move kafka and zookeeper configuration to `/etc/kafka` (`/opt` is read-only in bootc)
- Update to java 21.  Gradle supports Java 23, but the next packaged version on EL10 is Java 25.
- Upgrade Kafka to the latest 3.x version (4.x switches to Kraft.  We may want to do that soon, but I didn't want to do it in this PR.)
- Move config changes from `sed` in the spec file to a proper patch.