### PR TITLE
Remove venv ansible collection lock files

### DIFF
--- a/lib/manageiq/rpm_build/generate_ansible_venv.rb
+++ b/lib/manageiq/rpm_build/generate_ansible_venv.rb
@@ -72,6 +72,10 @@ module ManageIQ
 
           # Remove unnecessary large files
           FileUtils.rm_rf(Dir.glob("lib*/python*/site-packages/msgraph/generated/kiota-dom-export.txt")) # https://github.com/microsoftgraph/msgraph-sdk-python/issues/1287
+
+          # Remove lockfiles
+          FileUtils.rm_rf(Dir.glob("lib*/python*/site-packages/ansible_collections/**/Pipfile.lock"))
+          FileUtils.rm_rf(Dir.glob("lib*/python*/site-packages/ansible_collections/**/poetry.lock"))
         end
       end
 


### PR DESCRIPTION
The presence of these lock files causes false positives in certain image scanners, particularly aquasec/trivvy. aqua assumes that the presence of a lockfile indicates the package is also installed, which in the case of then ansible_collections is not true. This commit removes the lockfiles in order to avoid the false positives generated.

@bdunne Please review.