### PR TITLE
Remove concurrency from shared workflow

### DIFF
--- a/.github/workflows/update_rpm_repo.yaml
+++ b/.github/workflows/update_rpm_repo.yaml
@@ -4,9 +4,6 @@ on:
   - cron: 0 0 * * *
   workflow_call:
   workflow_dispatch:
-concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
The concurrency causes a deadlock when used from another workflow that also defines concurrency.

@bdunne Please review.