### PR TITLE
Fix pylxca build failure due to missing source file

### DIFF
--- a/packages/python-pylxca/build
+++ b/packages/python-pylxca/build
@@ -2,7 +2,7 @@
 
 set -e
 
-curl --fail -o pylxca-2.1.1.tar.gz https://rpm.manageiq.org/sources_cache/python-pylxca/pylxca-2.1.1.tar.gz
+curl --fail -o pylxca-4.2.0.tar.gz https://rpm.manageiq.org/sources_cache/python-pylxca/pylxca-4.2.0.tar.gz
 
 /usr/bin/mock --spec=./python-pylxca.spec -r centos-stream-10-$(uname -m) --sources=./ --no-bootstrap-image
 


### PR DESCRIPTION
This was missed in #630 
Error: https://github.com/ManageIQ/manageiq-rpm_build/actions/runs/25473934143/job/74743273747#step:3:2106
```
ERROR: Exception(./python-pylxca.spec) Config(centos-stream-10-x86_64) 0 minutes 48 seconds INFO: Results and/or logs in: /var/lib/mock/centos-stream-10-x86_64/result ERROR: Command failed:
 # bash --login -c '/usr/bin/rpmbuild -bs --noclean --target x86_64 --nodeps /builddir/build/SPECS/python-pylxca.spec'

Error: Process completed with exit code 1.
```
