### PR TITLE
Add an automated way to update the ansible requirements

### DIFF
--- a/.github/workflows/update_ansible_reqs.yaml
+++ b/.github/workflows/update_ansible_reqs.yaml
@@ -1,0 +1,46 @@
+name: Update Ansible Requirements
+on:
+  schedule:
+  - cron: 0 0 * * 0
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  build_rpm_build_container:
+    if: github.repository_owner == 'ManageIQ'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up registry credentials
+      run: |
+        echo "REGISTRY_USERNAME=${{ secrets.DOCKER_REGISTRY_USERNAME }}" >> $GITHUB_ENV
+        echo "REGISTRY_PASSWORD=${{ secrets.DOCKER_REGISTRY_PASSWORD }}" >> $GITHUB_ENV
+    - name: Build and push RPM build image
+      run: bin/build_container_image
+  update_ansible_reqs:
+    needs: build_rpm_build_container
+    if: github.repository_owner == 'ManageIQ'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Update Ansible Requirements
+      run: bin/run_update_ansible_reqs
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v8
+      with:
+        add-paths: |
+          config/requirements.txt
+        commit-message: Update Ansible requirements
+        branch: update_ansible_reqs
+        assignees: Fryguy
+        author: ManageIQ Bot <bot@manageiq.org>
+        committer: ManageIQ Bot <bot@manageiq.org>
+        delete-branch: true
+        labels: dependencies
+        push-to-fork: miq-bot/manageiq-rpm_build
+        title: Update Ansible requirements
+        body: Update Ansible requirements
+        token: "${{ secrets.PR_TOKEN }}"

--- a/bin/parse_requirements.rb
+++ b/bin/parse_requirements.rb
@@ -1,30 +1,9 @@
 #!/usr/bin/env ruby
 
-# This script takes the existing requirements.txt file
-# and updates it with the version for our supported packages
+# Takes the existing requirements.txt file and updates it with the versions for
+# our supported ansible collections.
 #
-# USAGE:
-#
-# 1. Setup environment
-#
-#     docker run --rm -it --platform=linux/amd64 --name update_venv_reqs --entrypoint /bin/bash manageiq/rpm_build:latest
-#     pip3.12 install ansible
-#     cd build_scripts
-#
-# 2. Get all module requirements
-#
-#     bin/parse_requirements.rb config/requirements.txt /usr/local/lib/python3.12/site-packages/ansible_collections/ > config/new_requirements.txt
-#
-# 3. Resolve conflicts and determine if new one is correct.
-#    Double check that the legacy ones are still needed and, if not, remove them.
-#
-#     diff config/{,new_}requirements.txt
-#
-# 4. Update local development files
-#
-#     docker cp update_venv_reqs:/build_scripts/config/new_requirements.txt ./config/requirements.txt
-#     # create a PR with updates
-#
+# This script is designed to be called from bin/update_ansible_reqs
 class ParseRequirements
   # this is the list of supported collections
   PACKAGES = %w[

--- a/bin/run_update_ansible_reqs
+++ b/bin/run_update_ansible_reqs
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This script assumes that docker.io/manageiq/rpm_build:latest exists locally
+# either by running bin/build_container_image or pulling the latest.
+
+ARCH=${ARCH:=$(uname -m | sed 's/x86_64/amd64/')}
+
+docker run -it --rm \
+  --platform=linux/$ARCH \
+  --pull never \
+  --volume "$(pwd)/config:/tmp/config" \
+  --entrypoint /build_scripts/bin/update_ansible_reqs \
+  docker.io/manageiq/rpm_build:latest
+
+echo
+git diff config/requirements.txt

--- a/bin/update_ansible_reqs
+++ b/bin/update_ansible_reqs
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This script is designed to be run inside the manageiq-rpm_build container in
+# order to get the new set of requirements for the ansible venv. It should be
+# run from outside the container by the bin/run_update_ansible_reqs script.
+
+echo "Installing ansible..."
+pip3.12 install ansible
+
+echo
+echo "Parsing requirements.txt..."
+cd build_scripts
+bin/parse_requirements.rb config/requirements.txt /usr/local/lib/python3.12/site-packages/ansible_collections/ > /tmp/config/requirements.txt


### PR DESCRIPTION
@bdunne Please review. I'm intentionally not include the updated config/requirements.txt, so we can have that for a "first run" of the workflow.

I tested this locally by running

```
$ ARCH=amd64 bin/build_container_image
# Image got built

$ ARCH=amd64 bin/run_update_ansible_reqs
Installing ansible...
Collecting ansible
  Downloading ansible-13.6.0-py3-none-any.whl.metadata (8.1 kB)
Collecting ansible-core~=2.20.5 (from ansible)
  Downloading ansible_core-2.20.5-py3-none-any.whl.metadata (7.7 kB)
Requirement already satisfied: jinja2>=3.1.0 in /usr/lib/python3.12/site-packages (from ansible-core~=2.20.5->ansible) (3.1.6)
Requirement already satisfied: PyYAML>=5.1 in /usr/lib64/python3.12/site-packages (from ansible-core~=2.20.5->ansible) (6.0.1)
Requirement already satisfied: cryptography in /usr/lib64/python3.12/site-packages (from ansible-core~=2.20.5->ansible) (43.0.0)
Requirement already satisfied: packaging in /usr/lib/python3.12/site-packages (from ansible-core~=2.20.5->ansible) (24.2)
Collecting resolvelib<2.0.0,>=0.8.0 (from ansible-core~=2.20.5->ansible)
  Downloading resolvelib-1.2.1-py3-none-any.whl.metadata (3.7 kB)
Requirement already satisfied: MarkupSafe>=2.0 in /usr/lib64/python3.12/site-packages (from jinja2>=3.1.0->ansible-core~=2.20.5->ansible) (2.1.3)
Requirement already satisfied: cffi>=1.12 in /usr/lib64/python3.12/site-packages (from cryptography->ansible-core~=2.20.5->ansible) (1.16.0)
Requirement already satisfied: pycparser in /usr/lib/python3.12/site-packages (from cffi>=1.12->cryptography->ansible-core~=2.20.5->ansible) (2.20)
Requirement already satisfied: ply==3.11 in /usr/lib/python3.12/site-packages (from pycparser->cffi>=1.12->cryptography->ansible-core~=2.20.5->ansible) (3.11)
Downloading ansible-13.6.0-py3-none-any.whl (56.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 56.3/56.3 MB 6.2 MB/s eta 0:00:00
Downloading ansible_core-2.20.5-py3-none-any.whl (2.4 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.4/2.4 MB 4.6 MB/s eta 0:00:00
Downloading resolvelib-1.2.1-py3-none-any.whl (18 kB)
Installing collected packages: resolvelib, ansible-core, ansible
Successfully installed ansible-13.6.0 ansible-core-2.20.5 resolvelib-1.2.1
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv

Parsing requirements.txt...
rpm: no arguments given for query
kubernetes: >=24.2.0 > >=12.0.0
netaddr: >=1.3.0 > >=0.10.1
requests: >=2.32.5 > >=2.4.2
update_ansible_reqs

diff --git a/config/requirements.txt b/config/requirements.txt
index ef46a80..046d0fc 100644
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.13.0 # azure/azcollection
-ansible-pylibssh>=0.2.0 # ansible/netcommon
+ansible-pylibssh>=1.4.0 # ansible/netcommon
 awxkit # awx/awx
 azure-ai-ml>=1.31.0 # azure/azcollection
 azure-appconfiguration>=1.8.0 # azure/azcollection
@@ -60,7 +60,7 @@ azure-servicebus>=7.14.2 # azure/azcollection
 azure-storage-blob>=12.23.0b1 # azure/azcollection
 boto3>=1.34.0 # amazon/aws, community/aws
 botocore>=1.34.0 # amazon/aws, community/aws
-cryptography # cisco/intersight
+cryptography>=36.0.0 # cisco/intersight
 google-auth # google/cloud
 google-cloud-storage # google/cloud
 grpcio # ansible/netcommon
@@ -75,7 +75,7 @@ openstacksdk>=1.0.0 # openstack/cloud
 oras>=0.2.38 # azure/azcollection
 ovirt-engine-sdk-python>=4.5.0 # ovirt/ovirt
 ovirt-imageio # ovirt/ovirt
-packaging # azure/azcollection
+packaging>=25.0 # azure/azcollection
 pandas>=2.3.3 # azure/azcollection
 paramiko # ansible/netcommon
 protobuf>=6.32 # ansible/netcommon
```