### PR TITLE
We're already on rpm-build v4.19.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,9 +65,7 @@ RUN echo "gem: --no-ri --no-rdoc --no-document" > /root/.gemrc
 
 COPY . /build_scripts
 
-RUN curl -o /usr/lib/rpm/brp-strip https://raw.githubusercontent.com/rpm-software-management/rpm/rpm-4.19.1-release/scripts/brp-strip && \
-  chmod +x /usr/lib/rpm/brp-strip && \
-  cd /usr/lib/rpm/ && \
-  patch -p2 < /build_scripts/container-assets/Add-js-rb-filtering-on-top-of-4.19.1.patch
+RUN cd /usr/lib/rpm/ && \
+    patch -p2 < /build_scripts/container-assets/Add-js-rb-filtering-on-top-of-4.19.1.patch
 
 ENTRYPOINT ["/build_scripts/container-assets/user-entrypoint.sh"]


### PR DESCRIPTION
So, we no longer need to download brp-strip from github.
✂️ 🔥 🗑️ 