### PR TITLE
Drop python3-cryptography since we install a newer version from pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,6 @@ RUN --mount=type=bind,from=quay.io/manageiq/build_tools:v1,source=/tools,target=
       make \
       openssl-devel \
       python3.12-devel \
-      python3.12-cryptography \
       python3.12-packaging \
       python3.12-pip \
       python3.12-pyyaml \

--- a/rpm_spec/subpackages/manageiq-ansible-venv
+++ b/rpm_spec/subpackages/manageiq-ansible-venv
@@ -4,7 +4,6 @@ Summary: %{product_summary} Ansible Runner Virtual Environment
 %global __requires_exclude ^\/var\/lib\/manageiq\/venv\/bin\/python
 
 Requires: python3.12
-Requires: python3.12-cryptography
 Requires: python3.12-pip
 Requires: python3.12-wheel
 # For ansible-core


### PR DESCRIPTION
The RPM version is older and potentially vulnerable to several CVEs, but we already install the newer version from pip as part of our ansible-venv
