### PR TITLE
Fixes to update_ansible_reqs

### DIFF
--- a/bin/run_update_ansible_reqs
+++ b/bin/run_update_ansible_reqs
@@ -6,8 +6,9 @@ set -e
 # either by running bin/build_container_image or pulling the latest.
 
 ARCH=${ARCH:=$(uname -m | sed 's/x86_64/amd64/')}
+TTY_FLAGS=$([ -t 0 ] && echo "-it")
 
-docker run -it --rm \
+docker run $TTY_FLAGS --rm \
   --platform=linux/$ARCH \
   --pull never \
   --volume "$(pwd)/config:/tmp/config" \

--- a/bin/run_update_ansible_reqs
+++ b/bin/run_update_ansible_reqs
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # This script assumes that docker.io/manageiq/rpm_build:latest exists locally
 # either by running bin/build_container_image or pulling the latest.
 

--- a/bin/update_ansible_reqs
+++ b/bin/update_ansible_reqs
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # This script is designed to be run inside the manageiq-rpm_build container in
 # order to get the new set of requirements for the ansible venv. It should be
 # run from outside the container by the bin/run_update_ansible_reqs script.


### PR DESCRIPTION
Follow up to #665 

- Add set -e to avoid successful failures
-  Check for a TTY before passing -it to docker
  In CI, we don't have a TTY. Locally we do, and want to accept input such as Ctrl-C to cancel early.

