### PR TITLE
Fix issue when TTY is not available

### DIFF
--- a/bin/run_update_ansible_reqs
+++ b/bin/run_update_ansible_reqs
@@ -6,7 +6,7 @@ set -e
 # either by running bin/build_container_image or pulling the latest.
 
 ARCH=${ARCH:=$(uname -m | sed 's/x86_64/amd64/')}
-TTY_FLAGS=$([ -t 0 ] && echo "-it")
+TTY_FLAGS=$([ -t 0 ] && echo "-it" || true)
 
 docker run $TTY_FLAGS --rm \
   --platform=linux/$ARCH \


### PR DESCRIPTION
When [ -t 0 ] returns false in CI, set -e causes the script to exit.

@bdunne Please review.

Followup to #670 which was a followup to #665 

GHA testing is so painful.