### PR TITLE
Ensure jinja2 presence for ansible venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN --mount=type=bind,from=quay.io/manageiq/build_tools:v1,source=/tools,target=
       make \
       openssl-devel \
       python3.12-devel \
+      python3.12-jinja2 \
       python3.12-packaging \
       python3.12-pip \
       python3.12-pyyaml \

--- a/rpm_spec/subpackages/manageiq-ansible-venv
+++ b/rpm_spec/subpackages/manageiq-ansible-venv
@@ -7,6 +7,7 @@ Requires: python3.12
 Requires: python3.12-pip
 Requires: python3.12-wheel
 # For ansible-core
+Requires: python3.12-jinja2
 Requires: python3.12-packaging
 Requires: python3.12-pyyaml
 AutoReqProv: no


### PR DESCRIPTION
jinja2 is being brought in by copr-cli, but it's a requirement of ansible. As such, during the ansible install it detects it and doesn't install it into the venv (expected). However, we didn't have it present at runtime in the production images (unexpected), creating issues.

This commit ensures it exists on both sides until we can remove copr-cli.

CP4AIOPS-28934

@bdunne Please review. cc @agrare 