### PR TITLE
Add CI workflow to validate config/requirements.txt changes

### DIFF
--- a/.github/workflows/ci-ansible_reqs.yaml
+++ b/.github/workflows/ci-ansible_reqs.yaml
@@ -1,0 +1,35 @@
+name: CI - Ansible Reqs
+on:
+  pull_request:
+    paths:
+    - config/requirements.txt
+  push:
+    branches-ignore:
+    - dependabot/*
+    - renovate/*
+    paths:
+    - config/requirements.txt
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  ci-ansible_reqs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          python3.12-venv \
+          libkrb5-dev \
+          libssh2-1-dev \
+          libffi-dev \
+          libssl-dev \
+          libxml2-dev \
+          libxslt1-dev
+    - name: Validate Ansible requirements
+      run: spec/test_ansible_reqs

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ packages/*/*.zip
 packages/*/result/*.rpm
 rpm_cache/
 rpm_spec/*.spec
+
+bin/test_ansible_runner_execution
+spec/lib/ansible/

--- a/spec/test_ansible_reqs
+++ b/spec/test_ansible_reqs
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+PYTHON_VERSION="3.12"
+VENV_PATH="/var/lib/manageiq/venv"
+
+# Build the venv at the production path (runner_execution_spec.bats hard-codes this)
+echo -e "\033[1;34mCreating venv at $VENV_PATH...\033[0m"
+sudo mkdir -p /var/lib/manageiq
+sudo chown "$USER" /var/lib/manageiq
+python${PYTHON_VERSION} -m venv --system-site-packages --upgrade-deps $VENV_PATH
+
+echo -e "\033[1;34mInstalling ansible + ansible-runner...\033[0m"
+$VENV_PATH/bin/pip${PYTHON_VERSION} install --no-compile ansible ansible-core ansible-runner
+
+echo -e "\033[1;34mInstalling requirements.txt...\033[0m"
+$VENV_PATH/bin/pip${PYTHON_VERSION} install --no-compile -r config/requirements.txt
+
+# Fetch test_ansible_runner_execution and the ansible specs from ManageIQ/manageiq.
+# We use a sparse checkout to avoid cloning the full repo.
+if [ ! -d "./spec/lib/ansible" ]; then
+  echo -e "\033[1;34mCloning ansible specs from ManageIQ/manageiq...\033[0m"
+  rm -rf /tmp/manageiq
+  git clone --no-checkout --depth=1 --filter=tree:0 https://github.com/ManageIQ/manageiq /tmp/manageiq
+  pushd /tmp/manageiq
+    git sparse-checkout set --no-cone /bin/test_ansible_runner_execution /spec/lib/ansible
+    git checkout
+  popd
+
+  mkdir -p ./spec/lib
+  cp -r /tmp/manageiq/spec/lib/ansible ./spec/lib
+  cp /tmp/manageiq/bin/test_ansible_runner_execution ./bin/test_ansible_runner_execution
+  chmod +x ./bin/test_ansible_runner_execution
+  rm -rf /tmp/manageiq
+fi
+
+# Run only the [ansible-runner] CLI tests — the [Ansible::Runner#run] tests require Rails.
+# BATS_FILTER is a regex, so "ansible-runner" matches all [ansible-runner] tests without
+# needing to escape brackets.
+BATS_FILTER="ansible-runner" exec ./bin/test_ansible_runner_execution


### PR DESCRIPTION
Adds spec/test_ansible_reqs which builds a Python 3.12 venv at /var/lib/manageiq/venv, installs ansible-runner and requirements.txt, then runs the [ansible-runner] CLI tests from ManageIQ/manageiq's runner_execution_spec.bats (via a sparse checkout).

Adds .github/workflows/ci-ansible_reqs.yaml to trigger this only when config/requirements.txt is changed on PRs or pushes.

Depends on
- [x] https://github.com/ManageIQ/manageiq/pull/23910

Needed by https://github.com/ManageIQ/manageiq-rpm_build/pull/679

@bdunne Please review.